### PR TITLE
Feat/editor store and column selection

### DIFF
--- a/__tests__/editorStore/useEditorStore.test.ts
+++ b/__tests__/editorStore/useEditorStore.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, jest } from '@jest/globals';
+import { columnSelectionFinish } from '@modules/editorStore/actions/columnSelectionFinish';
+import { columnSelectionHover } from '@modules/editorStore/actions/columnSelectionHover';
+import { columnSelectionStart } from '@modules/editorStore/actions/columnSelectionStart';
+import { resetEditor } from '@modules/editorStore/actions/resetEditor';
+import { initialState } from '@modules/editorStore/constants';
+import { useEditorStore } from '@modules/editorStore/useEditorStore';
+import { act, cleanup, renderHook } from '@testing-library/react';
+
+describe('useTablatureStore', () => {
+	afterEach(() => {
+		jest.resetAllMocks();
+		cleanup();
+		resetEditor();
+	});
+
+	it('[resetEditor] reset the entire state to the initial state.', () => {
+		const { result } = renderHook(() => useEditorStore((state) => state));
+
+		act(() => {
+			resetEditor();
+		});
+
+		expect(result.current).toEqual(initialState);
+	});
+
+	it('[columnSelectionStart] sets "isSelecting" flag true, sets "selectedColumns" appropriately.', () => {
+		const { result } = renderHook(() => useEditorStore((state) => state));
+
+		act(() => {
+			columnSelectionStart(0, 1);
+		});
+
+		expect(result.current.isSelecting).toEqual(true);
+		expect(result.current.selectedColumns).toEqual({ line: 0, start: 1, end: 1 });
+	});
+
+	it('[columnSelectionHover] sets "selectedColumns.end" appropriately.', () => {
+		const { result } = renderHook(() => useEditorStore((state) => state));
+
+		act(() => {
+			columnSelectionStart(0, 1);
+			columnSelectionHover(0, 5);
+		});
+
+		expect(result.current.isSelecting).toEqual(true);
+		expect(result.current.selectedColumns).toEqual({ line: 0, start: 1, end: 5 });
+	});
+
+	it('[columnSelectionFinish] sets "isSelecting" flag false.', () => {
+		const { result } = renderHook(() => useEditorStore((state) => state));
+
+		act(() => {
+			columnSelectionStart(0, 1);
+			columnSelectionHover(0, 5);
+			columnSelectionFinish();
+		});
+
+		expect(result.current.isSelecting).toEqual(false);
+		expect(result.current.selectedColumns).toEqual({ line: 0, start: 1, end: 5 });
+	});
+
+	it('[columnSelection(Start/Hover/Finish)] handles hovering on different line.', () => {
+		const { result } = renderHook(() => useEditorStore((state) => state));
+
+		act(() => {
+			columnSelectionStart(0, 1);
+			columnSelectionHover(1, 3);
+			columnSelectionFinish();
+		});
+
+		expect(result.current.isSelecting).toEqual(false);
+		expect(result.current.selectedColumns).toEqual({ line: 0, start: 1, end: 1 });
+	});
+});

--- a/__tests__/tablatureStore/useTablatureStore.test.ts
+++ b/__tests__/tablatureStore/useTablatureStore.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, jest } from '@jest/globals';
 import { changeInstrument } from '@modules/tablatureStore/actions/changeInstrument';
 import { changeTuning } from '@modules/tablatureStore/actions/changeTuning';
-import { clearTablature } from '@modules/tablatureStore/actions/clearTablature';
 import { insertBlankColumn } from '@modules/tablatureStore/actions/insertBlankColumn';
 import { pushBlankColumn } from '@modules/tablatureStore/actions/pushBlankColumn';
 import { pushBlankLine } from '@modules/tablatureStore/actions/pushBlankLine';
+import { resetTablature } from '@modules/tablatureStore/actions/resetTablature';
 import { electricBass, electricGuitar } from '@modules/tablatureStore/constants';
 import { useTablatureStore } from '@modules/tablatureStore/useTablatureStore';
 import { act, cleanup, renderHook } from '@testing-library/react';
@@ -26,13 +26,13 @@ describe('useTablatureStore', () => {
 		expect(result.current).toEqual(electricBass.createInitialState());
 	});
 
-	it('[clearTablature] revert the tablature to its default state.', () => {
+	it('[resetTablature] revert the tablature to its default state.', () => {
 		const { result } = renderHook(() => useTablatureStore((state) => state));
 
 		const blankTablature = result.current.instrument.BLANK_TABLATURE;
 
 		act(() => {
-			clearTablature();
+			resetTablature();
 		});
 
 		expect(result.current.tablature).toEqual(blankTablature);

--- a/src/common/Instrument.ts
+++ b/src/common/Instrument.ts
@@ -30,7 +30,7 @@ export class Instrument {
 			modifier: null,
 			cells: new Array<Cell>(amountOfStrings).fill(this.BLANK_CELL),
 		};
-		this.BLANK_LINE = { columns: [this.BLANK_COLUMN, this.BLANK_COLUMN] };
+		this.BLANK_LINE = { columns: new Array(8).fill(this.BLANK_COLUMN) };
 		this.BLANK_TABLATURE = { lines: [this.BLANK_LINE] };
 	}
 

--- a/src/modules/editorStore/actions/columnSelectionFinish.ts
+++ b/src/modules/editorStore/actions/columnSelectionFinish.ts
@@ -1,17 +1,7 @@
 import { editorStoreBase } from '../useEditorStore';
 
-export const columnSelectionFinish = (line: number, end: number) => {
+export const columnSelectionFinish = () => {
 	editorStoreBase.setState((state) => {
-		// if selection finishes on different line, or outside a column component
-		if (line !== state.selectedColumns.line || end < 0) {
-			state.selectedColumns = { ...state.selectedColumns, end: state.selectedColumns.start };
-			return;
-		}
-
-		let start = state.selectedColumns.start;
-		// swap values if necessary so start is always smaller than end
-		if (start > end) [start, end] = [end, start];
-
-		state.selectedColumns = { line, start, end };
+		state.isSelecting = false;
 	});
 };

--- a/src/modules/editorStore/actions/columnSelectionFinish.ts
+++ b/src/modules/editorStore/actions/columnSelectionFinish.ts
@@ -1,0 +1,17 @@
+import { editorStoreBase } from '../useEditorStore';
+
+export const columnSelectionFinish = (line: number, end: number) => {
+	editorStoreBase.setState((state) => {
+		// if selection finishes on different line, or outside a column component
+		if (line !== state.selectedColumns.line || end < 0) {
+			state.selectedColumns = { ...state.selectedColumns, end: state.selectedColumns.start };
+			return;
+		}
+
+		let start = state.selectedColumns.start;
+		// swap values if necessary so start is always smaller than end
+		if (start > end) [start, end] = [end, start];
+
+		state.selectedColumns = { line, start, end };
+	});
+};

--- a/src/modules/editorStore/actions/columnSelectionHover.ts
+++ b/src/modules/editorStore/actions/columnSelectionHover.ts
@@ -1,0 +1,10 @@
+import { editorStoreBase } from '../useEditorStore';
+
+export const columnSelectionHover = (lineIndex: number, columnIndex: number) => {
+	editorStoreBase.setState((state) => {
+		// if selection finishes on different line, or outside a column component
+		if (lineIndex !== state.selectedColumns.line || columnIndex < 0) return;
+
+		state.selectedColumns = { ...state.selectedColumns, end: columnIndex };
+	});
+};

--- a/src/modules/editorStore/actions/columnSelectionStart.ts
+++ b/src/modules/editorStore/actions/columnSelectionStart.ts
@@ -1,0 +1,11 @@
+import { editorStoreBase } from '../useEditorStore';
+
+export const columnSelectionStart = (line: number, start: number) => {
+	editorStoreBase.setState((state) => {
+		state.selectedColumns = {
+			line,
+			start,
+			end: start,
+		};
+	});
+};

--- a/src/modules/editorStore/actions/columnSelectionStart.ts
+++ b/src/modules/editorStore/actions/columnSelectionStart.ts
@@ -1,11 +1,12 @@
 import { editorStoreBase } from '../useEditorStore';
 
-export const columnSelectionStart = (line: number, start: number) => {
+export const columnSelectionStart = (lineIndex: number, columnIndex: number) => {
 	editorStoreBase.setState((state) => {
+		state.isSelecting = true;
 		state.selectedColumns = {
-			line,
-			start,
-			end: start,
+			line: lineIndex,
+			start: columnIndex,
+			end: columnIndex,
 		};
 	});
 };

--- a/src/modules/editorStore/actions/resetEditor.ts
+++ b/src/modules/editorStore/actions/resetEditor.ts
@@ -1,0 +1,4 @@
+import { initialState } from '../constants';
+import { editorStoreBase } from '../useEditorStore';
+
+export const resetEditor = () => editorStoreBase.setState(() => initialState);

--- a/src/modules/editorStore/actions/selectColumns.ts
+++ b/src/modules/editorStore/actions/selectColumns.ts
@@ -1,0 +1,9 @@
+import { editorStoreBase } from '../useEditorStore';
+
+export const selectColumns = (line: number, start: number, end: number) => {
+	editorStoreBase.setState((state) => {
+		// swap values so start is always smaller than end
+		if (start > end) [start, end] = [end, start];
+		state.selectedColumns = { line, start, end };
+	});
+};

--- a/src/modules/editorStore/actions/setColumnSelection.ts
+++ b/src/modules/editorStore/actions/setColumnSelection.ts
@@ -1,6 +1,6 @@
 import { editorStoreBase } from '../useEditorStore';
 
-export const selectColumns = (line: number, start: number, end: number) => {
+export const setColumnSelection = (line: number, start: number, end: number) => {
 	editorStoreBase.setState((state) => {
 		// swap values so start is always smaller than end
 		if (start > end) [start, end] = [end, start];

--- a/src/modules/editorStore/actions/setColumnSelection.ts
+++ b/src/modules/editorStore/actions/setColumnSelection.ts
@@ -2,8 +2,6 @@ import { editorStoreBase } from '../useEditorStore';
 
 export const setColumnSelection = (line: number, start: number, end: number) => {
 	editorStoreBase.setState((state) => {
-		// swap values so start is always smaller than end
-		if (start > end) [start, end] = [end, start];
 		state.selectedColumns = { line, start, end };
 	});
 };

--- a/src/modules/editorStore/constants.ts
+++ b/src/modules/editorStore/constants.ts
@@ -1,0 +1,8 @@
+export const initialState: EditorStore = {
+	isSelecting: false,
+	selectedColumns: {
+		line: -1,
+		start: -1,
+		end: -1,
+	},
+};

--- a/src/modules/editorStore/index.d.ts
+++ b/src/modules/editorStore/index.d.ts
@@ -1,0 +1,9 @@
+interface EditorStore {
+	selectedColumns: ColumnSelection;
+}
+
+interface ColumnSelection {
+	line: number;
+	start: number;
+	end: number;
+}

--- a/src/modules/editorStore/index.d.ts
+++ b/src/modules/editorStore/index.d.ts
@@ -1,4 +1,5 @@
 interface EditorStore {
+	isSelecting: boolean;
 	selectedColumns: ColumnSelection;
 }
 

--- a/src/modules/editorStore/logger.ts
+++ b/src/modules/editorStore/logger.ts
@@ -1,0 +1,24 @@
+import { StateCreator, StoreMutatorIdentifier } from 'zustand';
+
+type Logger = <
+	T extends EditorStore,
+	Mps extends [StoreMutatorIdentifier, unknown][] = [],
+	Mcs extends [StoreMutatorIdentifier, unknown][] = []
+>(
+	f: StateCreator<T, Mps, Mcs>
+) => StateCreator<T, Mps, Mcs>;
+
+type LoggerImpl = <T extends EditorStore>(f: StateCreator<T, [], []>) => StateCreator<T, [], []>;
+
+const loggerImpl: LoggerImpl = (f) => (set, get, store) => {
+	const loggedSet: typeof set = (...a) => {
+		set(...a);
+		console.log(get());
+	};
+
+	store.setState = loggedSet;
+
+	return f(loggedSet, get, store);
+};
+
+export const logger = loggerImpl as unknown as Logger;

--- a/src/modules/editorStore/useEditorStore.ts
+++ b/src/modules/editorStore/useEditorStore.ts
@@ -4,6 +4,7 @@ import { immer } from 'zustand/middleware/immer';
 import { logger } from './logger';
 
 const initialState: EditorStore = {
+	isSelecting: false,
 	selectedColumns: {
 		line: -1,
 		start: -1,

--- a/src/modules/editorStore/useEditorStore.ts
+++ b/src/modules/editorStore/useEditorStore.ts
@@ -1,0 +1,28 @@
+import { create, StoreApi, UseBoundStore } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+
+import { logger } from './logger';
+
+const initialState: EditorStore = {
+	selectedColumns: {
+		line: -1,
+		start: -1,
+		end: -1,
+	},
+};
+export const editorStoreBase = create(logger(immer<EditorStore>(() => initialState)));
+
+type WithSelectors<S> = S extends { getState: () => infer T } ? S & { use: { [K in keyof T]: () => T[K] } } : never;
+
+const createSelectors = <S extends UseBoundStore<StoreApi<object>>>(_store: S) => {
+	const store = _store as WithSelectors<typeof _store>;
+	store.use = {};
+	for (const k of Object.keys(store.getState())) {
+		// eslint-disable-next-line
+		(store.use as any)[k] = () => store((s) => s[k as keyof typeof s]);
+	}
+
+	return store;
+};
+
+export const useEditorStore = createSelectors(editorStoreBase);

--- a/src/modules/editorStore/useEditorStore.ts
+++ b/src/modules/editorStore/useEditorStore.ts
@@ -1,16 +1,9 @@
 import { create, StoreApi, UseBoundStore } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 
+import { initialState } from './constants';
 import { logger } from './logger';
 
-const initialState: EditorStore = {
-	isSelecting: false,
-	selectedColumns: {
-		line: -1,
-		start: -1,
-		end: -1,
-	},
-};
 export const editorStoreBase = create(logger(immer<EditorStore>(() => initialState)));
 
 type WithSelectors<S> = S extends { getState: () => infer T } ? S & { use: { [K in keyof T]: () => T[K] } } : never;

--- a/src/modules/tablatureEditor/components/Cell.tsx
+++ b/src/modules/tablatureEditor/components/Cell.tsx
@@ -5,7 +5,11 @@ interface Props {
 }
 
 const Cell = ({ cell }: Props) => {
-	return <div className={styles.cell}>{cell.fret === -1 ? '-' : cell.fret}</div>;
+	return (
+		<div data-testid='cell' className={styles.cell}>
+			{cell.fret === -1 ? '-' : cell.fret}
+		</div>
+	);
 };
 
 export default Cell;

--- a/src/modules/tablatureEditor/components/Column.module.scss
+++ b/src/modules/tablatureEditor/components/Column.module.scss
@@ -1,5 +1,5 @@
 .column {
-	&.selected {
+	&[data-selected='true'] {
 		color: $c-background;
 		background-color: $c-foreground;
 	}

--- a/src/modules/tablatureEditor/components/Column.module.scss
+++ b/src/modules/tablatureEditor/components/Column.module.scss
@@ -1,5 +1,8 @@
 .column {
-	margin-right: 1px;
+	&.selected {
+		color: $c-background;
+		background-color: $c-foreground;
+	}
 
 	&:hover {
 		background-color: $c-medium;

--- a/src/modules/tablatureEditor/components/Column.tsx
+++ b/src/modules/tablatureEditor/components/Column.tsx
@@ -23,11 +23,14 @@ const Column = memo<Props>(({ lineIndex, columnIndex, column, isSelected }) => {
 	const onMouseDown: MouseEventHandler<HTMLDivElement> = (e) => {
 		e.stopPropagation();
 		columnSelectionStart(lineIndex, columnIndex);
-	};
-
-	const onMouseUp: MouseEventHandler<HTMLDivElement> = (e) => {
-		e.stopPropagation();
-		columnSelectionFinish();
+		document.addEventListener(
+			'mouseup',
+			(e) => {
+				e.stopPropagation();
+				columnSelectionFinish();
+			},
+			{ once: true }
+		);
 	};
 
 	const onMouseOver: MouseEventHandler<HTMLDivElement> = () => {
@@ -39,7 +42,6 @@ const Column = memo<Props>(({ lineIndex, columnIndex, column, isSelected }) => {
 			className={isSelected ? styles.column + ' ' + styles.selected : styles.column}
 			data-col-idx={columnIndex}
 			onMouseDown={onMouseDown}
-			onMouseUp={onMouseUp}
 			onMouseOver={onMouseOver}
 		>
 			{column.cells.map((cell, i) => (

--- a/src/modules/tablatureEditor/components/Column.tsx
+++ b/src/modules/tablatureEditor/components/Column.tsx
@@ -2,12 +2,21 @@ import Cell from './Cell';
 import styles from './Column.module.scss';
 
 interface Props {
+	index: number;
 	column: Column;
+	isSelected: boolean;
+	onMouseUp(columnIndex: number): void;
+	onMouseDown(columnIndex: number): void;
 }
 
-const Column = ({ column }: Props) => {
+const Column = ({ index, column, isSelected, onMouseUp, onMouseDown }: Props) => {
 	return (
-		<div className={styles.column}>
+		<div
+			className={isSelected ? styles.column + ' ' + styles.selected : styles.column}
+			data-col-idx={index}
+			onMouseDown={() => onMouseDown(index)}
+			onMouseUp={() => onMouseUp(index)}
+		>
 			{column.cells.map((cell, i) => (
 				<Cell key={i} cell={cell} />
 			))}

--- a/src/modules/tablatureEditor/components/Column.tsx
+++ b/src/modules/tablatureEditor/components/Column.tsx
@@ -1,27 +1,45 @@
+import { memo, MouseEventHandler } from 'react';
+
+import { columnSelectionFinish } from '@modules/editorStore/actions/columnSelectionFinish';
+import { columnSelectionStart } from '@modules/editorStore/actions/columnSelectionStart';
+
 import Cell from './Cell';
 import styles from './Column.module.scss';
 
 interface Props {
-	index: number;
+	lineIndex: number;
+	columnIndex: number;
 	column: Column;
 	isSelected: boolean;
-	onMouseUp(columnIndex: number): void;
-	onMouseDown(columnIndex: number): void;
 }
 
-const Column = ({ index, column, isSelected, onMouseUp, onMouseDown }: Props) => {
+const Column = memo<Props>(({ lineIndex, columnIndex, column, isSelected }) => {
+	const onMouseDown: MouseEventHandler<HTMLDivElement> = (e) => {
+		e.stopPropagation();
+		columnSelectionStart(lineIndex, columnIndex);
+
+		// if mouseup event is triggered anywhere ELSE in the window, finish the selection
+		// window.addEventListener('mouseup', () => columnSelectionFinish(lineIndex, columnIndex), { once: true });
+	};
+
+	const onMouseUp: MouseEventHandler<HTMLDivElement> = (e) => {
+		e.stopPropagation();
+		columnSelectionFinish(lineIndex, columnIndex);
+	};
+
 	return (
 		<div
 			className={isSelected ? styles.column + ' ' + styles.selected : styles.column}
-			data-col-idx={index}
-			onMouseDown={() => onMouseDown(index)}
-			onMouseUp={() => onMouseUp(index)}
+			data-col-idx={columnIndex}
+			onMouseDown={onMouseDown}
+			onMouseUp={onMouseUp}
 		>
 			{column.cells.map((cell, i) => (
 				<Cell key={i} cell={cell} />
 			))}
 		</div>
 	);
-};
+});
 
+Column.displayName = 'Column';
 export default Column;

--- a/src/modules/tablatureEditor/components/Column.tsx
+++ b/src/modules/tablatureEditor/components/Column.tsx
@@ -39,8 +39,9 @@ const Column = memo<Props>(({ lineIndex, columnIndex, column, isSelected }) => {
 
 	return (
 		<div
-			className={isSelected ? styles.column + ' ' + styles.selected : styles.column}
-			data-col-idx={columnIndex}
+			data-testid='column'
+			data-selected={isSelected}
+			className={styles.column}
 			onMouseDown={onMouseDown}
 			onMouseOver={onMouseOver}
 		>

--- a/src/modules/tablatureEditor/components/Column.tsx
+++ b/src/modules/tablatureEditor/components/Column.tsx
@@ -1,6 +1,7 @@
 import { memo, MouseEventHandler } from 'react';
 
 import { columnSelectionFinish } from '@modules/editorStore/actions/columnSelectionFinish';
+import { columnSelectionHover } from '@modules/editorStore/actions/columnSelectionHover';
 import { columnSelectionStart } from '@modules/editorStore/actions/columnSelectionStart';
 
 import Cell from './Cell';
@@ -27,12 +28,17 @@ const Column = memo<Props>(({ lineIndex, columnIndex, column, isSelected }) => {
 		columnSelectionFinish(lineIndex, columnIndex);
 	};
 
+	const onMouseOver: MouseEventHandler<HTMLDivElement> = () => {
+		if (isSelecting) columnSelectionHover(lineIndex, columnIndex);
+	};
+
 	return (
 		<div
 			className={isSelected ? styles.column + ' ' + styles.selected : styles.column}
 			data-col-idx={columnIndex}
 			onMouseDown={onMouseDown}
 			onMouseUp={onMouseUp}
+			onMouseOver={onMouseOver}
 		>
 			{column.cells.map((cell, i) => (
 				<Cell key={i} cell={cell} />

--- a/src/modules/tablatureEditor/components/Column.tsx
+++ b/src/modules/tablatureEditor/components/Column.tsx
@@ -3,6 +3,7 @@ import { memo, MouseEventHandler } from 'react';
 import { columnSelectionFinish } from '@modules/editorStore/actions/columnSelectionFinish';
 import { columnSelectionHover } from '@modules/editorStore/actions/columnSelectionHover';
 import { columnSelectionStart } from '@modules/editorStore/actions/columnSelectionStart';
+import { useEditorStore } from '@modules/editorStore/useEditorStore';
 
 import Cell from './Cell';
 import styles from './Column.module.scss';
@@ -14,18 +15,19 @@ interface Props {
 	isSelected: boolean;
 }
 
+const isSelectingSelector = (state: EditorStore) => state.isSelecting;
+
 const Column = memo<Props>(({ lineIndex, columnIndex, column, isSelected }) => {
+	const isSelecting = useEditorStore(isSelectingSelector);
+
 	const onMouseDown: MouseEventHandler<HTMLDivElement> = (e) => {
 		e.stopPropagation();
 		columnSelectionStart(lineIndex, columnIndex);
-
-		// if mouseup event is triggered anywhere ELSE in the window, finish the selection
-		// window.addEventListener('mouseup', () => columnSelectionFinish(lineIndex, columnIndex), { once: true });
 	};
 
 	const onMouseUp: MouseEventHandler<HTMLDivElement> = (e) => {
 		e.stopPropagation();
-		columnSelectionFinish(lineIndex, columnIndex);
+		columnSelectionFinish();
 	};
 
 	const onMouseOver: MouseEventHandler<HTMLDivElement> = () => {

--- a/src/modules/tablatureEditor/components/Line.tsx
+++ b/src/modules/tablatureEditor/components/Line.tsx
@@ -11,25 +11,26 @@ const between = (num: number, a: number, b: number) => {
 };
 
 interface Props {
-	index: number;
+	lineIndex: number;
 	line: Line;
 }
 
-const Line = ({ index, line }: Props) => {
+const Line = ({ lineIndex, line }: Props) => {
 	const selectedColumns = useEditorStore().selectedColumns;
 
 	return (
 		<div className={styles.line}>
 			{line.columns.map((column, columnIndex) => {
 				const isSelected =
-					index === selectedColumns.line && between(columnIndex, selectedColumns.start, selectedColumns.end);
+					lineIndex === selectedColumns.line &&
+					between(columnIndex, selectedColumns.start, selectedColumns.end);
 
 				return (
 					<Column
 						key={columnIndex}
-						lineIndex={index}
-						columnIndex={columnIndex}
 						column={column}
+						lineIndex={lineIndex}
+						columnIndex={columnIndex}
 						isSelected={isSelected}
 					/>
 				);

--- a/src/modules/tablatureEditor/components/Line.tsx
+++ b/src/modules/tablatureEditor/components/Line.tsx
@@ -3,6 +3,13 @@ import { useEditorStore } from '@modules/editorStore/useEditorStore';
 import Column from './Column';
 import styles from './Line.module.scss';
 
+// checks if 'num' is between 'a' and 'b'
+const between = (num: number, a: number, b: number) => {
+	const min = Math.min.apply(Math, [a, b]),
+		max = Math.max.apply(Math, [a, b]);
+	return num >= min && num <= max;
+};
+
 interface Props {
 	index: number;
 	line: Line;
@@ -15,9 +22,7 @@ const Line = ({ index, line }: Props) => {
 		<div className={styles.line}>
 			{line.columns.map((column, columnIndex) => {
 				const isSelected =
-					index === selectedColumns.line &&
-					columnIndex >= selectedColumns.start &&
-					columnIndex <= selectedColumns.end;
+					index === selectedColumns.line && between(columnIndex, selectedColumns.start, selectedColumns.end);
 
 				return (
 					<Column

--- a/src/modules/tablatureEditor/components/Line.tsx
+++ b/src/modules/tablatureEditor/components/Line.tsx
@@ -19,7 +19,7 @@ const Line = ({ lineIndex, line }: Props) => {
 	const selectedColumns = useEditorStore().selectedColumns;
 
 	return (
-		<div className={styles.line}>
+		<div className={styles.line} data-testid='line'>
 			{line.columns.map((column, columnIndex) => {
 				const isSelected =
 					lineIndex === selectedColumns.line &&

--- a/src/modules/tablatureEditor/components/Line.tsx
+++ b/src/modules/tablatureEditor/components/Line.tsx
@@ -1,6 +1,3 @@
-import { useState } from 'react';
-
-import { selectColumns } from '@modules/editorStore/actions/selectColumns';
 import { useEditorStore } from '@modules/editorStore/useEditorStore';
 
 import Column from './Column';
@@ -12,29 +9,23 @@ interface Props {
 }
 
 const Line = ({ index, line }: Props) => {
-	const [selectionStart, setSelectionStart] = useState<number | null>(null);
 	const selectedColumns = useEditorStore().selectedColumns;
-
-	const onColumnMouseDown = (columnIndex: number) => setSelectionStart(columnIndex);
-
-	const onColumnMouseUp = (columnIndex: number) => {
-		if (selectionStart !== null) selectColumns(index, selectionStart, columnIndex);
-		setSelectionStart(null);
-	};
 
 	return (
 		<div className={styles.line}>
-			{line.columns.map((column, i) => {
+			{line.columns.map((column, columnIndex) => {
 				const isSelected =
-					index === selectedColumns.line && i >= selectedColumns.start && i <= selectedColumns.end;
+					index === selectedColumns.line &&
+					columnIndex >= selectedColumns.start &&
+					columnIndex <= selectedColumns.end;
+
 				return (
 					<Column
-						key={i}
-						index={i}
+						key={columnIndex}
+						lineIndex={index}
+						columnIndex={columnIndex}
 						column={column}
 						isSelected={isSelected}
-						onMouseUp={onColumnMouseUp}
-						onMouseDown={onColumnMouseDown}
 					/>
 				);
 			})}

--- a/src/modules/tablatureEditor/components/Line.tsx
+++ b/src/modules/tablatureEditor/components/Line.tsx
@@ -1,16 +1,43 @@
+import { useState } from 'react';
+
+import { selectColumns } from '@modules/editorStore/actions/selectColumns';
+import { useEditorStore } from '@modules/editorStore/useEditorStore';
+
 import Column from './Column';
 import styles from './Line.module.scss';
 
 interface Props {
+	index: number;
 	line: Line;
 }
 
-const Line = ({ line }: Props) => {
+const Line = ({ index, line }: Props) => {
+	const [selectionStart, setSelectionStart] = useState<number | null>(null);
+	const selectedColumns = useEditorStore().selectedColumns;
+
+	const onColumnMouseDown = (columnIndex: number) => setSelectionStart(columnIndex);
+
+	const onColumnMouseUp = (columnIndex: number) => {
+		if (selectionStart !== null) selectColumns(index, selectionStart, columnIndex);
+		setSelectionStart(null);
+	};
+
 	return (
 		<div className={styles.line}>
-			{line.columns.map((column, i) => (
-				<Column key={i} column={column} />
-			))}
+			{line.columns.map((column, i) => {
+				const isSelected =
+					index === selectedColumns.line && i >= selectedColumns.start && i <= selectedColumns.end;
+				return (
+					<Column
+						key={i}
+						index={i}
+						column={column}
+						isSelected={isSelected}
+						onMouseUp={onColumnMouseUp}
+						onMouseDown={onColumnMouseDown}
+					/>
+				);
+			})}
 		</div>
 	);
 };

--- a/src/modules/tablatureEditor/components/Tablature.cy.tsx
+++ b/src/modules/tablatureEditor/components/Tablature.cy.tsx
@@ -1,0 +1,38 @@
+import Tablature from './Tablature';
+
+const columnIsSelected = (e: JQuery<HTMLElement>) => expect(e).to.have.attr('data-selected', 'true');
+const columnIsNotSelected = (e: JQuery<HTMLElement>) => expect(e).to.have.attr('data-selected', 'false');
+
+describe('Column selection', () => {
+	it('multiple columns can be selected with mouse events.', () => {
+		cy.mount(<Tablature />);
+
+		const firstColumn = cy.getTestElement('line').getTestElement('column').first();
+
+		firstColumn
+			.trigger('mousedown')
+			.should(columnIsSelected)
+			.next()
+			.trigger('mouseover')
+			.should(columnIsSelected)
+			.next()
+			.trigger('mouseover')
+			.trigger('mouseup')
+			.should(columnIsSelected)
+			.next()
+			.trigger('mouseover')
+			.should(columnIsNotSelected);
+	});
+
+	it('stops selecting when mouseup event is triggered outside column component.', () => {
+		cy.mount(<Tablature />);
+		const tablature = cy.getTestElement('tablature');
+		const firstColumn = cy.getTestElement('line').getTestElement('column').first().should(columnIsSelected);
+
+		firstColumn.trigger('mousedown').should(columnIsSelected);
+
+		tablature.trigger('mouseover').trigger('mouseup');
+
+		firstColumn.next().trigger('mouseover').should(columnIsNotSelected);
+	});
+});

--- a/src/modules/tablatureEditor/components/Tablature.cy.tsx
+++ b/src/modules/tablatureEditor/components/Tablature.cy.tsx
@@ -1,15 +1,24 @@
+import TablatureControls from './controls/TablatureControls';
 import Tablature from './Tablature';
 
+const getTablature = () => cy.getTestElement('tablature');
+const getColumn = (columnIndex: number, lineIndex = 0) =>
+	cy.getTestElement('line').eq(lineIndex).find('[data-testid="column"]').eq(columnIndex);
 const columnIsSelected = (e: JQuery<HTMLElement>) => expect(e).to.have.attr('data-selected', 'true');
 const columnIsNotSelected = (e: JQuery<HTMLElement>) => expect(e).to.have.attr('data-selected', 'false');
 
 describe('Column selection', () => {
-	it('multiple columns can be selected with mouse events.', () => {
-		cy.mount(<Tablature />);
+	beforeEach(() => {
+		cy.mount(
+			<>
+				<Tablature />
+				<TablatureControls />
+			</>
+		);
+	});
 
-		const firstColumn = cy.getTestElement('line').getTestElement('column').first();
-
-		firstColumn
+	it('can select multiple columns from left-to-right.', () => {
+		getColumn(0)
 			.trigger('mousedown')
 			.should(columnIsSelected)
 			.next()
@@ -24,15 +33,37 @@ describe('Column selection', () => {
 			.should(columnIsNotSelected);
 	});
 
-	it('stops selecting when mouseup event is triggered outside column component.', () => {
-		cy.mount(<Tablature />);
-		const tablature = cy.getTestElement('tablature');
-		const firstColumn = cy.getTestElement('line').getTestElement('column').first().should(columnIsSelected);
+	it('can select mutliple columns from right-to-left.', () => {
+		getColumn(3)
+			.trigger('mousedown')
+			.should(columnIsSelected)
+			.prev()
+			.trigger('mouseover')
+			.should(columnIsSelected)
+			.prev()
+			.trigger('mouseover')
+			.trigger('mouseup')
+			.should(columnIsSelected)
+			.prev()
+			.trigger('mouseover')
+			.should(columnIsNotSelected);
+	});
 
-		firstColumn.trigger('mousedown').should(columnIsSelected);
+	it('stops selecting when "mouseup" event is triggered outside of Column component.', () => {
+		getColumn(0).trigger('mousedown').should(columnIsSelected);
+		getTablature().trigger('mouseover').trigger('mouseup');
+		getColumn(1).trigger('mouseover').should(columnIsNotSelected);
+	});
 
-		tablature.trigger('mouseover').trigger('mouseup');
+	it('clears the selection when the Tablature component is clicked.', () => {
+		getColumn(0).click().should(columnIsSelected);
+		getTablature().click();
+		getColumn(0).should(columnIsNotSelected);
+	});
 
-		firstColumn.next().trigger('mouseover').should(columnIsNotSelected);
+	it('prevents starting a selection on one line, and ending on another.', () => {
+		cy.getTestElement('pushBlankLine').click();
+		getColumn(0).trigger('mousedown').should(columnIsSelected);
+		getColumn(0, 1).trigger('mouseover').trigger('mouseup').should(columnIsNotSelected);
 	});
 });

--- a/src/modules/tablatureEditor/components/Tablature.module.scss
+++ b/src/modules/tablatureEditor/components/Tablature.module.scss
@@ -3,4 +3,5 @@
 	border: 1px solid $c-foreground;
 	font-family: $font-mono;
 	font-size: 12px;
+	user-select: none;
 }

--- a/src/modules/tablatureEditor/components/Tablature.tsx
+++ b/src/modules/tablatureEditor/components/Tablature.tsx
@@ -9,6 +9,7 @@ const Tablature = () => {
 
 	return (
 		<div
+			data-testid='tablature'
 			className={styles.tablature}
 			onMouseDown={() => {
 				// remove selection on mouse down

--- a/src/modules/tablatureEditor/components/Tablature.tsx
+++ b/src/modules/tablatureEditor/components/Tablature.tsx
@@ -17,7 +17,7 @@ const Tablature = ({ tablature }: Props) => {
 			}}
 		>
 			{tablature.lines.map((line, i) => (
-				<Line key={i} index={i} line={line} />
+				<Line key={i} lineIndex={i} line={line} />
 			))}
 		</div>
 	);

--- a/src/modules/tablatureEditor/components/Tablature.tsx
+++ b/src/modules/tablatureEditor/components/Tablature.tsx
@@ -1,3 +1,5 @@
+import { setColumnSelection } from '@modules/editorStore/actions/setColumnSelection';
+
 import Line from './Line';
 import styles from './Tablature.module.scss';
 
@@ -7,7 +9,13 @@ interface Props {
 
 const Tablature = ({ tablature }: Props) => {
 	return (
-		<div className={styles.tablature}>
+		<div
+			className={styles.tablature}
+			onMouseDown={() => {
+				// remove selection on mouse down
+				setColumnSelection(-1, -1, -1);
+			}}
+		>
 			{tablature.lines.map((line, i) => (
 				<Line key={i} index={i} line={line} />
 			))}

--- a/src/modules/tablatureEditor/components/Tablature.tsx
+++ b/src/modules/tablatureEditor/components/Tablature.tsx
@@ -1,13 +1,12 @@
 import { setColumnSelection } from '@modules/editorStore/actions/setColumnSelection';
+import { useTablatureStore } from '@modules/tablatureStore/useTablatureStore';
 
 import Line from './Line';
 import styles from './Tablature.module.scss';
 
-interface Props {
-	tablature: Tablature;
-}
+const Tablature = () => {
+	const tablature = useTablatureStore().tablature;
 
-const Tablature = ({ tablature }: Props) => {
 	return (
 		<div
 			className={styles.tablature}

--- a/src/modules/tablatureEditor/components/Tablature.tsx
+++ b/src/modules/tablatureEditor/components/Tablature.tsx
@@ -9,7 +9,7 @@ const Tablature = ({ tablature }: Props) => {
 	return (
 		<div className={styles.tablature}>
 			{tablature.lines.map((line, i) => (
-				<Line key={i} line={line} />
+				<Line key={i} index={i} line={line} />
 			))}
 		</div>
 	);

--- a/src/modules/tablatureEditor/components/controls/TablatureControls.tsx
+++ b/src/modules/tablatureEditor/components/controls/TablatureControls.tsx
@@ -1,8 +1,8 @@
 import { changeInstrument } from '@modules/tablatureStore/actions/changeInstrument';
-import { clearTablature } from '@modules/tablatureStore/actions/clearTablature';
 import { insertBlankColumn } from '@modules/tablatureStore/actions/insertBlankColumn';
 import { pushBlankColumn } from '@modules/tablatureStore/actions/pushBlankColumn';
 import { pushBlankLine } from '@modules/tablatureStore/actions/pushBlankLine';
+import { resetTablature } from '@modules/tablatureStore/actions/resetTablature';
 import { electricBass, electricGuitar } from '@modules/tablatureStore/constants';
 
 import styles from './TablatureControls.module.scss';
@@ -13,8 +13,7 @@ const TablatureControls = () => {
 			<button onClick={() => pushBlankColumn(0)}>pushBlankColumn</button>
 			<button onClick={() => insertBlankColumn(0, 0)}>insertBlankColumn</button>
 			<button onClick={() => pushBlankLine()}>pushBlankLine</button>
-			<button onClick={() => clearTablature()}>clearTablature</button>
-			<button onClick={() => clearTablature()}>clearTablature</button>
+			<button onClick={() => resetTablature()}>resetTablature</button>
 			<button onClick={() => changeInstrument(electricGuitar)}>changeInstrument electricGuitar</button>
 			<button onClick={() => changeInstrument(electricBass)}>changeInstrument electricBass</button>
 		</div>

--- a/src/modules/tablatureEditor/components/controls/TablatureControls.tsx
+++ b/src/modules/tablatureEditor/components/controls/TablatureControls.tsx
@@ -10,12 +10,24 @@ import styles from './TablatureControls.module.scss';
 const TablatureControls = () => {
 	return (
 		<div className={styles['tablature-controls']}>
-			<button onClick={() => pushBlankColumn(0)}>pushBlankColumn</button>
-			<button onClick={() => insertBlankColumn(0, 0)}>insertBlankColumn</button>
-			<button onClick={() => pushBlankLine()}>pushBlankLine</button>
-			<button onClick={() => resetTablature()}>resetTablature</button>
-			<button onClick={() => changeInstrument(electricGuitar)}>changeInstrument electricGuitar</button>
-			<button onClick={() => changeInstrument(electricBass)}>changeInstrument electricBass</button>
+			<button data-testid='pushBlankColumn' onClick={() => pushBlankColumn(0)}>
+				pushBlankColumn
+			</button>
+			<button data-testid='insertBlankColumn' onClick={() => insertBlankColumn(0, 0)}>
+				insertBlankColumn
+			</button>
+			<button data-testid='pushBlankLine' onClick={() => pushBlankLine()}>
+				pushBlankLine
+			</button>
+			<button data-testid='resetTablature' onClick={() => resetTablature()}>
+				resetTablature
+			</button>
+			<button data-testid='changeInstrument guitar' onClick={() => changeInstrument(electricGuitar)}>
+				changeInstrument electricGuitar
+			</button>
+			<button data-testid='changeInstrument bass' onClick={() => changeInstrument(electricBass)}>
+				changeInstrument electricBass
+			</button>
 		</div>
 	);
 };

--- a/src/modules/tablatureStore/actions/changeInstrument.ts
+++ b/src/modules/tablatureStore/actions/changeInstrument.ts
@@ -1,5 +1,9 @@
 import type { Instrument } from '@common/Instrument';
+import { resetEditor } from '@modules/editorStore/actions/resetEditor';
+
 import { tablatureStoreBase } from '../useTablatureStore';
 
-export const changeInstrument = (instrument: Instrument) =>
+export const changeInstrument = (instrument: Instrument) => {
 	tablatureStoreBase.setState(instrument.createInitialState());
+	resetEditor();
+};

--- a/src/modules/tablatureStore/actions/resetTablature.ts
+++ b/src/modules/tablatureStore/actions/resetTablature.ts
@@ -1,6 +1,6 @@
 import { tablatureStoreBase } from '../useTablatureStore';
 
-export const clearTablature = () =>
+export const resetTablature = () =>
 	tablatureStoreBase.setState((state) => {
 		state.tablature = state.instrument.BLANK_TABLATURE;
 	});

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,12 +3,9 @@ import Head from 'next/head';
 import Fretboard from '@modules/fretboard/components/Fretboard';
 import TablatureControls from '@modules/tablatureEditor/components/controls/TablatureControls';
 import Tablature from '@modules/tablatureEditor/components/Tablature';
-import { useTablatureStore } from '@modules/tablatureStore/useTablatureStore';
 import styles from '@styles/pages/index.module.scss';
 
 export default function Home() {
-	const tablature = useTablatureStore().tablature;
-
 	return (
 		<>
 			<Head>
@@ -20,7 +17,7 @@ export default function Home() {
 			<main className={styles.main}>
 				<Fretboard />
 				<div className={styles.tablature}>
-					<Tablature tablature={tablature} />
+					<Tablature />
 					<TablatureControls />
 				</div>
 			</main>


### PR DESCRIPTION
Created a separate store for holding the editor options and state.
Added the logic for column selection in the tablature editor.

![image](https://user-images.githubusercontent.com/23709455/231884696-b928ccb8-6010-4620-9f1e-4d695b4e0009.png)