### PR TITLE
Feat/column ghost selection

### DIFF
--- a/__tests__/editorSlice/columnSelection.test.ts
+++ b/__tests__/editorSlice/columnSelection.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, jest } from '@jest/globals';
 import { columnSelectionFinish } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionFinish';
 import { columnSelectionHover } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionHover';
 import { columnSelectionStart } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionStart';
+import { resetColumnSelection } from '@modules/tablatureEditorStore/editorSlice/actions/resetColumnSelection';
 import { resetEditor } from '@modules/tablatureEditorStore/editorSlice/actions/resetEditor';
+import { setColumnSelection } from '@modules/tablatureEditorStore/editorSlice/actions/setColumnSelection';
 import { BLANK_SELECTION } from '@modules/tablatureEditorStore/editorSlice/constants';
 import { useTablatureEditorStore } from '@modules/tablatureEditorStore/useTablatureEditorStore';
 import { act, cleanup, renderHook } from '@testing-library/react';
@@ -12,6 +14,21 @@ describe('Column Selection Tests', () => {
 		jest.resetAllMocks();
 		cleanup();
 		resetEditor();
+	});
+
+	describe('[resetColumnSelection]', () => {
+		it('sets currentSelection and ghostSelection to blank selection.', () => {
+			const { result } = renderHook(() => useTablatureEditorStore((state) => state));
+
+			act(() => {
+				setColumnSelection(0, 1, 4);
+				resetColumnSelection();
+			});
+
+			expect(result.current.isSelecting).toBe(false);
+			expect(result.current.currentSelection).toEqual(BLANK_SELECTION);
+			expect(result.current.ghostSelection).toEqual(BLANK_SELECTION);
+		});
 	});
 
 	describe('[columnSelectionStart]', () => {

--- a/__tests__/editorSlice/columnSelection.test.ts
+++ b/__tests__/editorSlice/columnSelection.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, jest } from '@jest/globals';
+import { columnSelectionFinish } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionFinish';
+import { columnSelectionHover } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionHover';
+import { columnSelectionStart } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionStart';
+import { resetEditor } from '@modules/tablatureEditorStore/editorSlice/actions/resetEditor';
+import { BLANK_SELECTION } from '@modules/tablatureEditorStore/editorSlice/constants';
+import { useTablatureEditorStore } from '@modules/tablatureEditorStore/useTablatureEditorStore';
+import { act, cleanup, renderHook } from '@testing-library/react';
+
+describe('Column Selection Tests', () => {
+	afterEach(() => {
+		jest.resetAllMocks();
+		cleanup();
+		resetEditor();
+	});
+
+	describe('[columnSelectionStart]', () => {
+		it('sets "isSelecting" true.', () => {
+			const { result } = renderHook(() => useTablatureEditorStore((state) => state));
+
+			act(() => columnSelectionStart(0, 1));
+
+			expect(result.current.isSelecting).toBe(true);
+		});
+
+		it('sets "ghostSelection" appropriately.', () => {
+			const { result } = renderHook(() => useTablatureEditorStore((state) => state));
+
+			act(() => columnSelectionStart(0, 1));
+
+			expect(result.current.ghostSelection).toEqual({ line: 0, start: 1, end: 1 });
+		});
+	});
+
+	describe('[columnSelectionHover]', () => {
+		it('sets "ghostSelection.end" appropriately.', () => {
+			const { result } = renderHook(() => useTablatureEditorStore((state) => state));
+
+			act(() => {
+				columnSelectionStart(0, 1);
+				columnSelectionHover(0, 5);
+			});
+
+			expect(result.current.ghostSelection).toEqual({ line: 0, start: 1, end: 5 });
+		});
+
+		it('ignores hovering on different line.', () => {
+			const { result } = renderHook(() => useTablatureEditorStore((state) => state));
+
+			act(() => {
+				columnSelectionStart(0, 1);
+				columnSelectionHover(1, 3);
+			});
+
+			expect(result.current.ghostSelection).toEqual({ line: 0, start: 1, end: 1 });
+		});
+
+		it('throws error on out of bounds columnIndex.', () => {
+			const selectionHoverOutOfBounds = () =>
+				act(() => {
+					columnSelectionStart(0, 1);
+					columnSelectionHover(0, 500);
+				});
+
+			expect(selectionHoverOutOfBounds).toThrow('out of bounds');
+		});
+	});
+
+	describe('[columnSelectionFinish]', () => {
+		it('sets "isSelecting" flag false.', () => {
+			const { result } = renderHook(() => useTablatureEditorStore((state) => state));
+
+			act(() => {
+				columnSelectionStart(0, 1);
+				columnSelectionHover(0, 5);
+				columnSelectionFinish();
+			});
+
+			expect(result.current.isSelecting).toEqual(false);
+		});
+
+		it('sets "currentSelection" to equal "ghostSelection".', () => {
+			const { result } = renderHook(() => useTablatureEditorStore((state) => state));
+
+			act(() => {
+				columnSelectionStart(0, 1);
+				columnSelectionHover(0, 5);
+				columnSelectionFinish();
+			});
+
+			expect(result.current.currentSelection).toEqual({ line: 0, start: 1, end: 5 });
+		});
+
+		it('resets "ghostSelection" to blank selection.', () => {
+			const { result } = renderHook(() => useTablatureEditorStore((state) => state));
+
+			act(() => {
+				columnSelectionStart(0, 1);
+				columnSelectionHover(0, 5);
+				columnSelectionFinish();
+			});
+
+			expect(result.current.ghostSelection).toEqual(BLANK_SELECTION);
+		});
+
+		it('throws error on "ghostSelection" with null values.', () => {
+			const { result } = renderHook(() => useTablatureEditorStore((state) => state));
+
+			expect(result.current.ghostSelection).toEqual(BLANK_SELECTION);
+
+			const finishWithNullSelection = () => act(() => columnSelectionFinish());
+			expect(finishWithNullSelection).toThrow('null value');
+		});
+
+		it('finish with "start" > "end".', () => {
+			const { result } = renderHook(() => useTablatureEditorStore((state) => state));
+
+			act(() => {
+				columnSelectionStart(0, 6);
+				columnSelectionHover(0, 2);
+				columnSelectionFinish();
+			});
+
+			expect(result.current.currentSelection).toEqual({ line: 0, start: 2, end: 6 });
+		});
+	});
+});

--- a/__tests__/editorSlice/editorSlice.test.ts
+++ b/__tests__/editorSlice/editorSlice.test.ts
@@ -1,7 +1,4 @@
 import { describe, expect, jest } from '@jest/globals';
-import { columnSelectionFinish } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionFinish';
-import { columnSelectionHover } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionHover';
-import { columnSelectionStart } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionStart';
 import { resetEditor } from '@modules/tablatureEditorStore/editorSlice/actions/resetEditor';
 import { initialState } from '@modules/tablatureEditorStore/editorSlice/constants';
 import { useTablatureEditorStore } from '@modules/tablatureEditorStore/useTablatureEditorStore';
@@ -11,7 +8,6 @@ describe('useTablatureEditorStore', () => {
 	afterEach(() => {
 		jest.resetAllMocks();
 		cleanup();
-		resetEditor();
 	});
 
 	it('[resetEditor] reset the entire state to the initial state.', () => {
@@ -23,54 +19,5 @@ describe('useTablatureEditorStore', () => {
 
 		for (const key of Object.keys(initialState))
 			expect(result.current[key as keyof EditorSlice]).toEqual(initialState[key as keyof EditorSlice]);
-	});
-
-	it('[columnSelectionStart] sets "isSelecting" flag true, sets "selectedColumns" appropriately.', () => {
-		const { result } = renderHook(() => useTablatureEditorStore((state) => state));
-
-		act(() => {
-			columnSelectionStart(0, 1);
-		});
-
-		expect(result.current.isSelecting).toEqual(true);
-		expect(result.current.selectedColumns).toEqual({ line: 0, start: 1, end: 1 });
-	});
-
-	it('[columnSelectionHover] sets "selectedColumns.end" appropriately.', () => {
-		const { result } = renderHook(() => useTablatureEditorStore((state) => state));
-
-		act(() => {
-			columnSelectionStart(0, 1);
-			columnSelectionHover(0, 5);
-		});
-
-		expect(result.current.isSelecting).toEqual(true);
-		expect(result.current.selectedColumns).toEqual({ line: 0, start: 1, end: 5 });
-	});
-
-	it('[columnSelectionFinish] sets "isSelecting" flag false.', () => {
-		const { result } = renderHook(() => useTablatureEditorStore((state) => state));
-
-		act(() => {
-			columnSelectionStart(0, 1);
-			columnSelectionHover(0, 5);
-			columnSelectionFinish();
-		});
-
-		expect(result.current.isSelecting).toEqual(false);
-		expect(result.current.selectedColumns).toEqual({ line: 0, start: 1, end: 5 });
-	});
-
-	it('[columnSelection(Start/Hover/Finish)] handles hovering on different line.', () => {
-		const { result } = renderHook(() => useTablatureEditorStore((state) => state));
-
-		act(() => {
-			columnSelectionStart(0, 1);
-			columnSelectionHover(1, 3);
-			columnSelectionFinish();
-		});
-
-		expect(result.current.isSelecting).toEqual(false);
-		expect(result.current.selectedColumns).toEqual({ line: 0, start: 1, end: 1 });
 	});
 });

--- a/src/modules/tablatureEditor/components/Column.module.scss
+++ b/src/modules/tablatureEditor/components/Column.module.scss
@@ -1,5 +1,6 @@
 .column {
-	&[data-selected='true'] {
+	&[data-selected='true'],
+	&[data-ghost-selected='true'] {
 		color: $c-background;
 		background-color: $c-foreground;
 	}

--- a/src/modules/tablatureEditor/components/Column.tsx
+++ b/src/modules/tablatureEditor/components/Column.tsx
@@ -13,11 +13,12 @@ interface Props {
 	columnIndex: number;
 	column: Column;
 	isSelected: boolean;
+	isGhostSelected: boolean;
 }
 
 const isSelectingSelector = (state: EditorSlice) => state.isSelecting;
 
-const Column = memo<Props>(({ lineIndex, columnIndex, column, isSelected }) => {
+const Column = memo<Props>(({ lineIndex, columnIndex, column, isSelected, isGhostSelected }) => {
 	const isSelecting = useTablatureEditorStore(isSelectingSelector);
 
 	const onMouseDown: MouseEventHandler<HTMLDivElement> = (e) => {
@@ -41,6 +42,7 @@ const Column = memo<Props>(({ lineIndex, columnIndex, column, isSelected }) => {
 		<div
 			data-testid='column'
 			data-selected={isSelected}
+			data-ghost-selected={isGhostSelected}
 			className={styles.column}
 			onMouseDown={onMouseDown}
 			onMouseOver={onMouseOver}

--- a/src/modules/tablatureEditor/components/Line.tsx
+++ b/src/modules/tablatureEditor/components/Line.tsx
@@ -16,12 +16,14 @@ interface Props {
 }
 
 const Line = ({ lineIndex, line }: Props) => {
-	const selectedColumns = useTablatureEditorStore((state) => state.selectedColumns);
+	const selectedColumns = useTablatureEditorStore((state) => state.currentSelection);
 
 	return (
 		<div className={styles.line} data-testid='line'>
 			{line.columns.map((column, columnIndex) => {
 				const isSelected =
+					!!selectedColumns.start &&
+					!!selectedColumns.end &&
 					lineIndex === selectedColumns.line &&
 					between(columnIndex, selectedColumns.start, selectedColumns.end);
 

--- a/src/modules/tablatureEditor/components/Line.tsx
+++ b/src/modules/tablatureEditor/components/Line.tsx
@@ -17,15 +17,22 @@ interface Props {
 
 const Line = ({ lineIndex, line }: Props) => {
 	const selectedColumns = useTablatureEditorStore((state) => state.currentSelection);
+	const ghostSelectedColumns = useTablatureEditorStore((state) => state.ghostSelection);
 
 	return (
 		<div className={styles.line} data-testid='line'>
 			{line.columns.map((column, columnIndex) => {
 				const isSelected =
-					!!selectedColumns.start &&
-					!!selectedColumns.end &&
+					selectedColumns.start !== null &&
+					selectedColumns.end !== null &&
 					lineIndex === selectedColumns.line &&
 					between(columnIndex, selectedColumns.start, selectedColumns.end);
+
+				const isGhostSelected =
+					ghostSelectedColumns.start !== null &&
+					ghostSelectedColumns.end !== null &&
+					lineIndex === ghostSelectedColumns.line &&
+					between(columnIndex, ghostSelectedColumns.start, ghostSelectedColumns.end);
 
 				return (
 					<Column
@@ -34,6 +41,7 @@ const Line = ({ lineIndex, line }: Props) => {
 						lineIndex={lineIndex}
 						columnIndex={columnIndex}
 						isSelected={isSelected}
+						isGhostSelected={isGhostSelected}
 					/>
 				);
 			})}

--- a/src/modules/tablatureEditor/components/Tablature.tsx
+++ b/src/modules/tablatureEditor/components/Tablature.tsx
@@ -1,4 +1,4 @@
-import { setColumnSelection } from '@modules/tablatureEditorStore/editorSlice/actions/setColumnSelection';
+import { resetColumnSelection } from '@modules/tablatureEditorStore/editorSlice/actions/resetColumnSelection';
 import { useTablatureEditorStore } from '@modules/tablatureEditorStore/useTablatureEditorStore';
 
 import Line from './Line';
@@ -11,10 +11,8 @@ const Tablature = () => {
 		<div
 			data-testid='tablature'
 			className={styles.tablature}
-			onMouseDown={() => {
-				// remove selection on mouse down
-				setColumnSelection(-1, -1, -1);
-			}}
+			// remove selection on mouse down
+			onMouseDown={() => resetColumnSelection()}
 		>
 			{tablature.lines.map((line, i) => (
 				<Line key={i} lineIndex={i} line={line} />

--- a/src/modules/tablatureEditorStore/editorSlice/actions/columnSelectionFinish.ts
+++ b/src/modules/tablatureEditorStore/editorSlice/actions/columnSelectionFinish.ts
@@ -1,6 +1,21 @@
 import { useTablatureEditorStore } from '../../useTablatureEditorStore';
+import { BLANK_SELECTION } from '../constants';
 
 export const columnSelectionFinish = () =>
 	useTablatureEditorStore.setState((state) => {
+		const { ghostSelection } = state;
+
+		if (ghostSelection.line === null || ghostSelection.start === null || ghostSelection.end === null)
+			throw new Error(
+				`Attempted to finish selection with a null value, line=${ghostSelection.line} start=${ghostSelection.start}, end=${ghostSelection.end}`
+			);
+
+		const [start, end] =
+			ghostSelection.start <= ghostSelection.end
+				? [ghostSelection.start, ghostSelection.end]
+				: [ghostSelection.end, ghostSelection.start];
+
 		state.isSelecting = false;
+		state.currentSelection = { ...ghostSelection, start, end };
+		state.ghostSelection = BLANK_SELECTION;
 	});

--- a/src/modules/tablatureEditorStore/editorSlice/actions/columnSelectionHover.ts
+++ b/src/modules/tablatureEditorStore/editorSlice/actions/columnSelectionHover.ts
@@ -2,8 +2,15 @@ import { useTablatureEditorStore } from '../../useTablatureEditorStore';
 
 export const columnSelectionHover = (lineIndex: number, columnIndex: number) =>
 	useTablatureEditorStore.setState((state) => {
-		// if selection finishes on different line, or outside a column component
-		if (lineIndex !== state.selectedColumns.line || columnIndex < 0) return;
+		// ignore if selection hovers on different line
+		if (lineIndex !== state.ghostSelection.line) return;
 
-		state.selectedColumns = { ...state.selectedColumns, end: columnIndex };
+		const line = state.tablature.lines[lineIndex];
+		if (!line) throw new Error(`Attempted to hover on out of bounds lineIndex: ${lineIndex}`);
+
+		// if hovered columnIndex is somehow outside the bounds of the line's columns
+		if (columnIndex < 0 || columnIndex > line.columns.length - 1)
+			throw new Error(`Attempted to hover on out of bounds columnIndex ${columnIndex} at lineIndex ${lineIndex}`);
+
+		state.ghostSelection = { ...state.ghostSelection, end: columnIndex };
 	});

--- a/src/modules/tablatureEditorStore/editorSlice/actions/columnSelectionStart.ts
+++ b/src/modules/tablatureEditorStore/editorSlice/actions/columnSelectionStart.ts
@@ -1,11 +1,13 @@
 import { useTablatureEditorStore } from '../../useTablatureEditorStore';
+import { BLANK_SELECTION } from '../constants';
 
 export const columnSelectionStart = (lineIndex: number, columnIndex: number) =>
 	useTablatureEditorStore.setState((state) => {
 		state.isSelecting = true;
-		state.selectedColumns = {
+		state.ghostSelection = {
 			line: lineIndex,
 			start: columnIndex,
 			end: columnIndex,
 		};
+		state.currentSelection = BLANK_SELECTION;
 	});

--- a/src/modules/tablatureEditorStore/editorSlice/actions/resetColumnSelection.ts
+++ b/src/modules/tablatureEditorStore/editorSlice/actions/resetColumnSelection.ts
@@ -1,0 +1,9 @@
+import { useTablatureEditorStore } from '../../useTablatureEditorStore';
+import { BLANK_SELECTION } from '../constants';
+
+export const resetColumnSelection = () =>
+	useTablatureEditorStore.setState((state) => {
+		state.isSelecting = false;
+		state.currentSelection = BLANK_SELECTION;
+		state.ghostSelection = BLANK_SELECTION;
+	});

--- a/src/modules/tablatureEditorStore/editorSlice/actions/setColumnSelection.ts
+++ b/src/modules/tablatureEditorStore/editorSlice/actions/setColumnSelection.ts
@@ -2,5 +2,5 @@ import { useTablatureEditorStore } from '../../useTablatureEditorStore';
 
 export const setColumnSelection = (line: number, start: number, end: number) =>
 	useTablatureEditorStore.setState((state) => {
-		state.selectedColumns = { line, start, end };
+		state.currentSelection = { line, start, end };
 	});

--- a/src/modules/tablatureEditorStore/editorSlice/constants.ts
+++ b/src/modules/tablatureEditorStore/editorSlice/constants.ts
@@ -1,8 +1,7 @@
+export const BLANK_SELECTION: ColumnSelection = { line: null, start: null, end: null };
+
 export const initialState: EditorSlice = {
 	isSelecting: false,
-	selectedColumns: {
-		line: -1,
-		start: -1,
-		end: -1,
-	},
+	ghostSelection: BLANK_SELECTION,
+	currentSelection: BLANK_SELECTION,
 };

--- a/src/modules/tablatureEditorStore/editorSlice/index.d.ts
+++ b/src/modules/tablatureEditorStore/editorSlice/index.d.ts
@@ -1,10 +1,11 @@
 interface EditorSlice {
 	isSelecting: boolean;
-	selectedColumns: ColumnSelection;
+	ghostSelection: ColumnSelection;
+	currentSelection: ColumnSelection;
 }
 
 interface ColumnSelection {
-	line: number;
-	start: number;
-	end: number;
+	line: number | null;
+	start: number | null;
+	end: number | null;
 }

--- a/src/modules/tablatureEditorStore/tablatureSlice/actions/clearSelectedColumns.ts
+++ b/src/modules/tablatureEditorStore/tablatureSlice/actions/clearSelectedColumns.ts
@@ -3,10 +3,8 @@ import { useTablatureEditorStore } from '@modules/tablatureEditorStore/useTablat
 import { iterateColumnSelection } from './utils/iterateColumnSelection';
 
 export const clearSelectedColumns = () =>
-	useTablatureEditorStore.setState((state) => {
-		const { line } = state.selectedColumns;
-
-		iterateColumnSelection((i) => {
-			state.tablature.lines[line].columns[i] = state.instrument.BLANK_COLUMN;
-		});
-	});
+	useTablatureEditorStore.setState((state) =>
+		iterateColumnSelection((i, currentSelection) => {
+			state.tablature.lines[currentSelection.line].columns[i] = state.instrument.BLANK_COLUMN;
+		})
+	);

--- a/src/modules/tablatureEditorStore/tablatureSlice/actions/setSelectedColumnsFret.ts
+++ b/src/modules/tablatureEditorStore/tablatureSlice/actions/setSelectedColumnsFret.ts
@@ -3,10 +3,8 @@ import { useTablatureEditorStore } from '@modules/tablatureEditorStore/useTablat
 import { iterateColumnSelection } from './utils/iterateColumnSelection';
 
 export const setSelectedColumnsFret = (stringNumber: number, fretNumber: number) =>
-	useTablatureEditorStore.setState((state) => {
-		const { line } = state.selectedColumns;
-
-		iterateColumnSelection((i) => {
-			state.tablature.lines[line].columns[i].cells[stringNumber].fret = fretNumber;
-		});
-	});
+	useTablatureEditorStore.setState((state) =>
+		iterateColumnSelection((i, currentSelection) => {
+			state.tablature.lines[currentSelection.line].columns[i].cells[stringNumber].fret = fretNumber;
+		})
+	);

--- a/src/modules/tablatureEditorStore/tablatureSlice/actions/utils/iterateColumnSelection.ts
+++ b/src/modules/tablatureEditorStore/tablatureSlice/actions/utils/iterateColumnSelection.ts
@@ -1,14 +1,17 @@
 import { useTablatureEditorStore } from '@modules/tablatureEditorStore/useTablatureEditorStore';
 
-export const iterateColumnSelection = (cb: (i: number) => void) => {
-	const selectedColumns = useTablatureEditorStore.getState().selectedColumns;
+type DeepNonNullable<T> = {
+	[P in keyof T]-?: NonNullable<T[P]>;
+};
 
-	if (selectedColumns.line < 0 || selectedColumns.start < 0 || selectedColumns.end < 0) return;
+export const iterateColumnSelection = (cb: (i: number, currentSelection: DeepNonNullable<ColumnSelection>) => void) => {
+	const currentSelection = useTablatureEditorStore.getState().currentSelection;
+	const { line, start, end } = currentSelection;
 
-	const [start, end] =
-		selectedColumns.start < selectedColumns.end
-			? [selectedColumns.start, selectedColumns.end]
-			: [selectedColumns.end, selectedColumns.start];
+	if (line === null || start === null || end === null)
+		throw new Error(
+			`Attempted to iterate over a selection with a null value, line=${line} start=${start}, end=${end}`
+		);
 
-	for (let i = start; i < end + 1; i++) cb(i);
+	for (let i = start; i < end + 1; i++) cb(i, currentSelection as DeepNonNullable<ColumnSelection>);
 };


### PR DESCRIPTION
Created a `ghostSelection` property on the tablature editor store. This is used to render the user's selection as it's being created. The finalized selection is stored in `currentSelection`.

Also made it so that in `currentSelection`, the `start` is always smaller than the `end`.