### PR TITLE
Feat/store undo and redo actions

### DIFF
--- a/__tests__/editorSlice/editorSlice.test.ts
+++ b/__tests__/editorSlice/editorSlice.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, jest } from '@jest/globals';
 import { resetEditor } from '@modules/tablatureEditorStore/editorSlice/actions/resetEditor';
-import { initialState } from '@modules/tablatureEditorStore/editorSlice/constants';
+import { editorInitialState } from '@modules/tablatureEditorStore/editorSlice/constants';
 import { useTablatureEditorStore } from '@modules/tablatureEditorStore/useTablatureEditorStore';
 import { act, cleanup, renderHook } from '@testing-library/react';
 
@@ -17,7 +17,7 @@ describe('useTablatureEditorStore', () => {
 			resetEditor();
 		});
 
-		for (const key of Object.keys(initialState))
-			expect(result.current[key as keyof EditorSlice]).toEqual(initialState[key as keyof EditorSlice]);
+		for (const key of Object.keys(editorInitialState))
+			expect(result.current[key as keyof EditorSlice]).toEqual(editorInitialState[key as keyof EditorSlice]);
 	});
 });

--- a/__tests__/undo.test.ts
+++ b/__tests__/undo.test.ts
@@ -102,6 +102,46 @@ describe('[setColumnSelection]', () => {
 	});
 });
 
+describe('[resetColumnSelection]', () => {
+	cleanupStore();
+
+	it('undoes selection reset.', () => {
+		const store = getTablatureStore();
+		const { undo } = getHistoryFns();
+
+		act(() => {
+			setColumnSelection(0, 1, 4);
+		});
+
+		expect(store.current.currentSelection).toEqual({ section: 0, start: 1, end: 4 });
+
+		act(() => {
+			resetColumnSelection();
+		});
+
+		expect(store.current.currentSelection).toEqual(BLANK_SELECTION);
+
+		act(() => {
+			undo();
+		});
+
+		expect(store.current.currentSelection).toEqual({ section: 0, start: 1, end: 4 });
+	});
+
+	it('redoes selection reset.', () => {
+		const store = getTablatureStore();
+		const { redo } = getHistoryFns();
+
+		expect(store.current.currentSelection).toEqual({ section: 0, start: 1, end: 4 });
+
+		act(() => {
+			redo();
+		});
+
+		expect(store.current.currentSelection).toEqual(BLANK_SELECTION);
+	});
+});
+
 describe('[changeInstrument]', () => {
 	cleanupStore();
 

--- a/__tests__/undo.test.ts
+++ b/__tests__/undo.test.ts
@@ -9,6 +9,7 @@ import { setColumnSelection } from '@modules/tablatureEditorStore/editorSlice/ac
 import { BLANK_SELECTION } from '@modules/tablatureEditorStore/editorSlice/constants';
 import { changeInstrument } from '@modules/tablatureEditorStore/tablatureSlice/actions/changeInstrument';
 import { changeTuning } from '@modules/tablatureEditorStore/tablatureSlice/actions/changeTuning';
+import { insertColumnsAtSelection } from '@modules/tablatureEditorStore/tablatureSlice/actions/insertColumnsAtSelection';
 import { setSelectedColumnsFret } from '@modules/tablatureEditorStore/tablatureSlice/actions/setSelectedColumnsFret';
 import { electricBass, electricGuitar } from '@modules/tablatureEditorStore/tablatureSlice/constants';
 import { useTablatureEditorStore } from '@modules/tablatureEditorStore/useTablatureEditorStore';
@@ -262,5 +263,44 @@ describe('[setSelectedColumnFret]', () => {
 			if (numIsBetweenRange(i, start, end)) expect(column.cells[stringNumber].fret).toEqual(fretNumber);
 			else expect(column).toEqual(store.current.instrument.BLANK_COLUMN);
 		});
+	});
+});
+
+describe('[insertColumnsAtSelection]', () => {
+	cleanupStore();
+
+	it('undoes inserting column.', () => {
+		const store = getTablatureStore();
+		const { undo } = getHistoryFns();
+
+		const column: Column = store.current.instrument.createColumnFromText('--2---');
+
+		act(() => {
+			setColumnSelection(0, 1, 1);
+			insertColumnsAtSelection([column]);
+		});
+
+		expect(store.current.tablature.sections[0].columns[2]).toEqual(column);
+
+		act(() => {
+			undo();
+		});
+
+		expect(store.current.tablature.sections[0].columns[2]).toEqual(store.current.instrument.BLANK_COLUMN);
+	});
+
+	it('redoes inserting column.', () => {
+		const store = getTablatureStore();
+		const { redo } = getHistoryFns();
+
+		const column: Column = store.current.instrument.createColumnFromText('--2---');
+
+		expect(store.current.tablature.sections[0].columns[2]).toEqual(store.current.instrument.BLANK_COLUMN);
+
+		act(() => {
+			redo();
+		});
+
+		expect(store.current.tablature.sections[0].columns[2]).toEqual(column);
 	});
 });

--- a/__tests__/undo.test.ts
+++ b/__tests__/undo.test.ts
@@ -1,13 +1,13 @@
-import { describe, expect, jest } from '@jest/globals';
+import { beforeAll, describe, expect, jest } from '@jest/globals';
+import { resetStore } from '@modules/tablatureEditorStore/actions/resetStore';
 import { columnSelectionFinish } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionFinish';
 import { columnSelectionHover } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionHover';
 import { columnSelectionStart } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionStart';
-import { resetEditor } from '@modules/tablatureEditorStore/editorSlice/actions/resetEditor';
+import { resetColumnSelection } from '@modules/tablatureEditorStore/editorSlice/actions/resetColumnSelection';
 import { setColumnSelection } from '@modules/tablatureEditorStore/editorSlice/actions/setColumnSelection';
 import { BLANK_SELECTION } from '@modules/tablatureEditorStore/editorSlice/constants';
 import { changeInstrument } from '@modules/tablatureEditorStore/tablatureSlice/actions/changeInstrument';
 import { changeTuning } from '@modules/tablatureEditorStore/tablatureSlice/actions/changeTuning';
-import { resetTablature } from '@modules/tablatureEditorStore/tablatureSlice/actions/resetTablature';
 import { electricBass, electricGuitar } from '@modules/tablatureEditorStore/tablatureSlice/constants';
 import { useTablatureEditorStore } from '@modules/tablatureEditorStore/useTablatureEditorStore';
 import { useTablatureHistoryStore } from '@modules/tablatureEditorStore/useTablatureHistoryStore';
@@ -23,14 +23,18 @@ const getHistoryFns = () => {
 	return result.current;
 };
 
-beforeEach(() => {
-	jest.clearAllMocks();
-	cleanup();
-	resetEditor();
-	resetTablature();
-});
+const cleanupStore = () =>
+	beforeAll(() => {
+		jest.clearAllMocks();
+		cleanup();
+		act(() => {
+			resetStore();
+		});
+	});
 
 describe('[columnSelection(start/hover/finish)]', () => {
+	cleanupStore();
+
 	it('undoes selection.', () => {
 		const store = getTablatureStore();
 		const { undo } = getHistoryFns();
@@ -65,6 +69,8 @@ describe('[columnSelection(start/hover/finish)]', () => {
 });
 
 describe('[setColumnSelection]', () => {
+	cleanupStore();
+
 	it('undoes selection.', () => {
 		const store = getTablatureStore();
 		const { undo } = getHistoryFns();
@@ -97,6 +103,8 @@ describe('[setColumnSelection]', () => {
 });
 
 describe('[changeInstrument]', () => {
+	cleanupStore();
+
 	it('undoes change to electricBass.', () => {
 		const store = getTablatureStore();
 		const { undo } = getHistoryFns();

--- a/__tests__/undo.test.ts
+++ b/__tests__/undo.test.ts
@@ -177,3 +177,39 @@ describe('[changeInstrument]', () => {
 		expect(store.current.instrument).toEqual(electricBass);
 	});
 });
+
+describe('[changeTuning]', () => {
+	cleanupStore();
+
+	it('undoes change to tuning.', () => {
+		const store = getTablatureStore();
+		const { undo } = getHistoryFns();
+
+		expect(store.current.tuning).toEqual(store.current.instrument.defaultTuning);
+
+		act(() => {
+			changeTuning([26, 33, 38, 43, 47, 52]);
+		});
+
+		expect(store.current.tuning).toEqual([26, 33, 38, 43, 47, 52]);
+
+		act(() => {
+			undo();
+		});
+
+		expect(store.current.tuning).toEqual(store.current.instrument.defaultTuning);
+	});
+
+	it('redoes change to tuning.', () => {
+		const store = getTablatureStore();
+		const { redo } = getHistoryFns();
+
+		expect(store.current.tuning).toEqual(store.current.instrument.defaultTuning);
+
+		act(() => {
+			redo();
+		});
+
+		expect(store.current.tuning).toEqual([26, 33, 38, 43, 47, 52]);
+	});
+});

--- a/__tests__/undo.test.ts
+++ b/__tests__/undo.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, jest } from '@jest/globals';
+import { columnSelectionFinish } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionFinish';
+import { columnSelectionHover } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionHover';
+import { columnSelectionStart } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionStart';
+import { resetEditor } from '@modules/tablatureEditorStore/editorSlice/actions/resetEditor';
+import { setColumnSelection } from '@modules/tablatureEditorStore/editorSlice/actions/setColumnSelection';
+import { BLANK_SELECTION } from '@modules/tablatureEditorStore/editorSlice/constants';
+import { changeInstrument } from '@modules/tablatureEditorStore/tablatureSlice/actions/changeInstrument';
+import { changeTuning } from '@modules/tablatureEditorStore/tablatureSlice/actions/changeTuning';
+import { resetTablature } from '@modules/tablatureEditorStore/tablatureSlice/actions/resetTablature';
+import { electricBass, electricGuitar } from '@modules/tablatureEditorStore/tablatureSlice/constants';
+import { useTablatureEditorStore } from '@modules/tablatureEditorStore/useTablatureEditorStore';
+import { useTablatureHistoryStore } from '@modules/tablatureEditorStore/useTablatureHistoryStore';
+import { act, cleanup, renderHook } from '@testing-library/react';
+
+const getTablatureStore = () => {
+	const { result } = renderHook(() => useTablatureEditorStore((state) => state));
+	return result;
+};
+
+const getHistoryFns = () => {
+	const { result } = renderHook(() => useTablatureHistoryStore((state) => state));
+	return result.current;
+};
+
+beforeEach(() => {
+	jest.clearAllMocks();
+	cleanup();
+	resetEditor();
+	resetTablature();
+});
+
+describe('[columnSelection(start/hover/finish)]', () => {
+	it('undoes selection.', () => {
+		const store = getTablatureStore();
+		const { undo } = getHistoryFns();
+
+		act(() => {
+			columnSelectionStart(0, 0);
+			columnSelectionHover(0, 6);
+			columnSelectionFinish();
+		});
+
+		expect(store.current.currentSelection).toEqual({ section: 0, start: 0, end: 6 });
+
+		act(() => {
+			undo();
+		});
+
+		expect(store.current.currentSelection).toEqual(BLANK_SELECTION);
+	});
+
+	it('redoes selection.', () => {
+		const store = getTablatureStore();
+		const { redo } = getHistoryFns();
+
+		expect(store.current.currentSelection).toEqual(BLANK_SELECTION);
+
+		act(() => {
+			redo();
+		});
+
+		expect(store.current.currentSelection).toEqual({ section: 0, start: 0, end: 6 });
+	});
+});
+
+describe('[setColumnSelection]', () => {
+	it('undoes selection.', () => {
+		const store = getTablatureStore();
+		const { undo } = getHistoryFns();
+
+		act(() => {
+			setColumnSelection(0, 1, 4);
+		});
+
+		expect(store.current.currentSelection).toEqual({ section: 0, start: 1, end: 4 });
+
+		act(() => {
+			undo();
+		});
+
+		expect(store.current.currentSelection).toEqual(BLANK_SELECTION);
+	});
+
+	it('redoes selection.', () => {
+		const store = getTablatureStore();
+		const { redo } = getHistoryFns();
+
+		expect(store.current.currentSelection).toEqual(BLANK_SELECTION);
+
+		act(() => {
+			redo();
+		});
+
+		expect(store.current.currentSelection).toEqual({ section: 0, start: 1, end: 4 });
+	});
+});
+
+describe('[changeInstrument]', () => {
+	it('undoes change to electricBass.', () => {
+		const store = getTablatureStore();
+		const { undo } = getHistoryFns();
+
+		expect(store.current.instrument).toEqual(electricGuitar);
+
+		act(() => {
+			changeInstrument(electricBass);
+		});
+
+		expect(store.current.instrument).toEqual(electricBass);
+
+		act(() => {
+			undo();
+		});
+
+		expect(store.current.instrument).toEqual(electricGuitar);
+	});
+
+	it('redoes change to electricBass.', () => {
+		const store = getTablatureStore();
+		const { redo } = getHistoryFns();
+
+		expect(store.current.instrument).toEqual(electricGuitar);
+
+		act(() => {
+			redo();
+		});
+
+		expect(store.current.instrument).toEqual(electricBass);
+	});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "next": "13.2.4",
                 "react": "18.2.0",
                 "react-dom": "18.2.0",
+                "zundo": "^2.0.0-beta.15",
                 "zustand": "^4.3.6"
             },
             "devDependencies": {
@@ -9787,6 +9788,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zundo": {
+            "version": "2.0.0-beta.15",
+            "resolved": "https://registry.npmjs.org/zundo/-/zundo-2.0.0-beta.15.tgz",
+            "integrity": "sha512-1mdzONJNOfX4h1UhO3HlAYFDrR59rE35V29MpfbDGShyCWC81rWuoeEJ1VNtMeHPO359g9FYpRsL/3NKQLmNow==",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://github.com/sponsors/charkour"
+            },
+            "peerDependencies": {
+                "zustand": "^4.3.0"
             }
         },
         "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "next": "13.2.4",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "zundo": "^2.0.0-beta.15",
         "zustand": "^4.3.6"
     },
     "devDependencies": {

--- a/src/modules/tablatureEditor/components/controls/TablatureControls.tsx
+++ b/src/modules/tablatureEditor/components/controls/TablatureControls.tsx
@@ -5,10 +5,12 @@ import { pushBlankColumn } from '@modules/tablatureEditorStore/tablatureSlice/ac
 import { pushBlankSection } from '@modules/tablatureEditorStore/tablatureSlice/actions/pushBlankSection';
 import { resetTablature } from '@modules/tablatureEditorStore/tablatureSlice/actions/resetTablature';
 import { electricBass, electricGuitar } from '@modules/tablatureEditorStore/tablatureSlice/constants';
+import { useTablatureHistoryStore } from '@modules/tablatureEditorStore/useTablatureHistoryStore';
 
 import styles from './TablatureControls.module.scss';
 
 const TablatureControls = () => {
+	const { undo, redo } = useTablatureHistoryStore((state) => state);
 	return (
 		<div className={styles['tablature-controls']}>
 			<button data-testid='pushBlankColumn' onClick={() => pushBlankColumn(0)}>
@@ -31,6 +33,12 @@ const TablatureControls = () => {
 			</button>
 			<button data-testid='changeInstrument bass' onClick={() => changeInstrument(electricBass)}>
 				changeInstrument electricBass
+			</button>
+			<button data-testid='undo' onClick={() => undo()}>
+				undo
+			</button>
+			<button data-testid='redo' onClick={() => redo()}>
+				redo
 			</button>
 		</div>
 	);

--- a/src/modules/tablatureEditorStore/actions/resetStore.ts
+++ b/src/modules/tablatureEditorStore/actions/resetStore.ts
@@ -2,5 +2,7 @@ import { editorInitialState } from '../editorSlice/constants';
 import { tablatureInitialState } from '../tablatureSlice/constants';
 import { useTablatureEditorStore } from '../useTablatureEditorStore';
 
-export const resetStore = () =>
+export const resetStore = () => {
 	useTablatureEditorStore.setState(() => ({ ...editorInitialState, ...tablatureInitialState }), true);
+	useTablatureEditorStore.temporal.getState().clear();
+};

--- a/src/modules/tablatureEditorStore/actions/resetStore.ts
+++ b/src/modules/tablatureEditorStore/actions/resetStore.ts
@@ -1,0 +1,6 @@
+import { editorInitialState } from '../editorSlice/constants';
+import { tablatureInitialState } from '../tablatureSlice/constants';
+import { useTablatureEditorStore } from '../useTablatureEditorStore';
+
+export const resetStore = () =>
+	useTablatureEditorStore.setState(() => ({ ...editorInitialState, ...tablatureInitialState }), true);

--- a/src/modules/tablatureEditorStore/editorSlice/actions/resetEditor.ts
+++ b/src/modules/tablatureEditorStore/editorSlice/actions/resetEditor.ts
@@ -1,4 +1,4 @@
 import { useTablatureEditorStore } from '../../useTablatureEditorStore';
-import { initialState } from '../constants';
+import { editorInitialState } from '../constants';
 
-export const resetEditor = () => useTablatureEditorStore.setState(() => initialState);
+export const resetEditor = () => useTablatureEditorStore.setState(() => editorInitialState);

--- a/src/modules/tablatureEditorStore/editorSlice/constants.ts
+++ b/src/modules/tablatureEditorStore/editorSlice/constants.ts
@@ -1,6 +1,6 @@
 export const BLANK_SELECTION: ColumnSelection = { section: null, start: null, end: null };
 
-export const initialState: EditorSlice = {
+export const editorInitialState: EditorSlice = {
 	isSelecting: false,
 	ghostSelection: BLANK_SELECTION,
 	currentSelection: BLANK_SELECTION,

--- a/src/modules/tablatureEditorStore/editorSlice/createEditorSlice.ts
+++ b/src/modules/tablatureEditorStore/editorSlice/createEditorSlice.ts
@@ -1,6 +1,6 @@
 import { StateCreator } from 'zustand';
 
-import { initialState } from './constants';
+import { editorInitialState } from './constants';
 
 export const createEditorSlice: StateCreator<TablatureEditorStore, [['zustand/immer', never]], [], EditorSlice> = () =>
-	initialState;
+	editorInitialState;

--- a/src/modules/tablatureEditorStore/tablatureSlice/constants.ts
+++ b/src/modules/tablatureEditorStore/tablatureSlice/constants.ts
@@ -27,3 +27,5 @@ export const electricGuitar = new Instrument(
 export const electricBass = new Instrument('Electric Bass', 4, 24, 'E Standard', [16, 21, 26, 31], {
 	'E Standard': [16, 21, 26, 31],
 });
+
+export const tablatureInitialState = electricGuitar.createInitialState();

--- a/src/modules/tablatureEditorStore/tablatureSlice/createTablatureSlice.ts
+++ b/src/modules/tablatureEditorStore/tablatureSlice/createTablatureSlice.ts
@@ -1,12 +1,10 @@
 import { StateCreator } from 'zustand';
 
-import { electricGuitar } from './constants';
-
-const initialState = electricGuitar.createInitialState();
+import { tablatureInitialState } from './constants';
 
 export const createTablatureSlice: StateCreator<
 	TablatureEditorStore,
 	[['zustand/immer', never]],
 	[],
 	TablatureSlice
-> = () => initialState;
+> = () => tablatureInitialState;

--- a/src/modules/tablatureEditorStore/useTablatureEditorStore.ts
+++ b/src/modules/tablatureEditorStore/useTablatureEditorStore.ts
@@ -15,6 +15,7 @@ export const useTablatureEditorStore = create(
 		{
 			partialize: (state) => ({ tablature: state.tablature }),
 			equality: shallow,
+			limit: 50,
 		}
 	)
 );

--- a/src/modules/tablatureEditorStore/useTablatureEditorStore.ts
+++ b/src/modules/tablatureEditorStore/useTablatureEditorStore.ts
@@ -1,3 +1,4 @@
+import { temporal } from 'zundo';
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 
@@ -5,8 +6,13 @@ import { createEditorSlice } from './editorSlice/createEditorSlice';
 import { createTablatureSlice } from './tablatureSlice/createTablatureSlice';
 
 export const useTablatureEditorStore = create(
-	immer<TablatureEditorStore>((...a) => ({
-		...createTablatureSlice(...a),
-		...createEditorSlice(...a),
-	}))
+	temporal(
+		immer<TablatureEditorStore>((...a) => ({
+			...createTablatureSlice(...a),
+			...createEditorSlice(...a),
+		})),
+		{
+			partialize: (state) => ({ tablature: state.tablature }),
+		}
+	)
 );

--- a/src/modules/tablatureEditorStore/useTablatureEditorStore.ts
+++ b/src/modules/tablatureEditorStore/useTablatureEditorStore.ts
@@ -13,7 +13,12 @@ export const useTablatureEditorStore = create(
 			...createEditorSlice(...a),
 		})),
 		{
-			partialize: (state) => ({ tablature: state.tablature }),
+			// don't save change history of 'ghostSelection' or 'isSelecting'
+			partialize: (state): Omit<TablatureEditorStore, 'ghostSelection' | 'isSelecting'> => {
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+				const { ghostSelection, isSelecting, ...rest } = state;
+				return rest;
+			},
 			equality: shallow,
 			limit: 50,
 		}

--- a/src/modules/tablatureEditorStore/useTablatureEditorStore.ts
+++ b/src/modules/tablatureEditorStore/useTablatureEditorStore.ts
@@ -1,6 +1,7 @@
 import { temporal } from 'zundo';
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
+import { shallow } from 'zustand/shallow';
 
 import { createEditorSlice } from './editorSlice/createEditorSlice';
 import { createTablatureSlice } from './tablatureSlice/createTablatureSlice';
@@ -13,6 +14,7 @@ export const useTablatureEditorStore = create(
 		})),
 		{
 			partialize: (state) => ({ tablature: state.tablature }),
+			equality: shallow,
 		}
 	)
 );

--- a/src/modules/tablatureEditorStore/useTablatureHistoryStore.ts
+++ b/src/modules/tablatureEditorStore/useTablatureHistoryStore.ts
@@ -1,0 +1,9 @@
+import type { TemporalState } from 'zundo';
+import { useStore } from 'zustand';
+
+import { useTablatureEditorStore } from './useTablatureEditorStore';
+
+export const useTablatureHistoryStore = <T>(
+	selector: (state: TemporalState<{ tablature: Tablature }>) => T,
+	equality?: (a: T, b: T) => boolean
+) => useStore(useTablatureEditorStore.temporal, selector, equality);

--- a/src/modules/tablatureEditorStore/useTablatureHistoryStore.ts
+++ b/src/modules/tablatureEditorStore/useTablatureHistoryStore.ts
@@ -4,6 +4,6 @@ import { useStore } from 'zustand';
 import { useTablatureEditorStore } from './useTablatureEditorStore';
 
 export const useTablatureHistoryStore = <T>(
-	selector: (state: TemporalState<{ tablature: Tablature }>) => T,
+	selector: (state: TemporalState<Omit<TablatureEditorStore, 'ghostSelection' | 'isSelecting'>>) => T,
 	equality?: (a: T, b: T) => boolean
 ) => useStore(useTablatureEditorStore.temporal, selector, equality);


### PR DESCRIPTION
Added undo and redo actions using the [zundo](https://github.com/charkour/zundo) package.

The `useTablatureHistoryStore` store keeps track of any change in value of the `useTablatureEditor` store except for `ghostSelection` and `isSelecting`.
Also, created Jest tests for undoing and redoing.