### PR TITLE
Fix/only track tablature history

### DIFF
--- a/__tests__/undo.test.ts
+++ b/__tests__/undo.test.ts
@@ -1,14 +1,8 @@
 import numIsBetweenRange from '@common/utils/numBetweenRange';
 import { beforeAll, describe, expect, jest } from '@jest/globals';
 import { resetStore } from '@modules/tablatureEditorStore/actions/resetStore';
-import { columnSelectionFinish } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionFinish';
-import { columnSelectionHover } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionHover';
-import { columnSelectionStart } from '@modules/tablatureEditorStore/editorSlice/actions/columnSelectionStart';
-import { resetColumnSelection } from '@modules/tablatureEditorStore/editorSlice/actions/resetColumnSelection';
 import { setColumnSelection } from '@modules/tablatureEditorStore/editorSlice/actions/setColumnSelection';
-import { BLANK_SELECTION } from '@modules/tablatureEditorStore/editorSlice/constants';
 import { changeInstrument } from '@modules/tablatureEditorStore/tablatureSlice/actions/changeInstrument';
-import { changeTuning } from '@modules/tablatureEditorStore/tablatureSlice/actions/changeTuning';
 import { insertColumnsAtSelection } from '@modules/tablatureEditorStore/tablatureSlice/actions/insertColumnsAtSelection';
 import { setSelectedColumnsFret } from '@modules/tablatureEditorStore/tablatureSlice/actions/setSelectedColumnsFret';
 import { electricBass, electricGuitar } from '@modules/tablatureEditorStore/tablatureSlice/constants';
@@ -34,116 +28,6 @@ const cleanupStore = () =>
 			resetStore();
 		});
 	});
-
-describe('[columnSelection(start/hover/finish)]', () => {
-	cleanupStore();
-
-	it('undoes selection.', () => {
-		const store = getTablatureStore();
-		const { undo } = getHistoryFns();
-
-		act(() => {
-			columnSelectionStart(0, 0);
-			columnSelectionHover(0, 6);
-			columnSelectionFinish();
-		});
-
-		expect(store.current.currentSelection).toEqual({ section: 0, start: 0, end: 6 });
-
-		act(() => {
-			undo();
-		});
-
-		expect(store.current.currentSelection).toEqual(BLANK_SELECTION);
-	});
-
-	it('redoes selection.', () => {
-		const store = getTablatureStore();
-		const { redo } = getHistoryFns();
-
-		expect(store.current.currentSelection).toEqual(BLANK_SELECTION);
-
-		act(() => {
-			redo();
-		});
-
-		expect(store.current.currentSelection).toEqual({ section: 0, start: 0, end: 6 });
-	});
-});
-
-describe('[setColumnSelection]', () => {
-	cleanupStore();
-
-	it('undoes selection.', () => {
-		const store = getTablatureStore();
-		const { undo } = getHistoryFns();
-
-		act(() => {
-			setColumnSelection(0, 1, 4);
-		});
-
-		expect(store.current.currentSelection).toEqual({ section: 0, start: 1, end: 4 });
-
-		act(() => {
-			undo();
-		});
-
-		expect(store.current.currentSelection).toEqual(BLANK_SELECTION);
-	});
-
-	it('redoes selection.', () => {
-		const store = getTablatureStore();
-		const { redo } = getHistoryFns();
-
-		expect(store.current.currentSelection).toEqual(BLANK_SELECTION);
-
-		act(() => {
-			redo();
-		});
-
-		expect(store.current.currentSelection).toEqual({ section: 0, start: 1, end: 4 });
-	});
-});
-
-describe('[resetColumnSelection]', () => {
-	cleanupStore();
-
-	it('undoes selection reset.', () => {
-		const store = getTablatureStore();
-		const { undo } = getHistoryFns();
-
-		act(() => {
-			setColumnSelection(0, 1, 4);
-		});
-
-		expect(store.current.currentSelection).toEqual({ section: 0, start: 1, end: 4 });
-
-		act(() => {
-			resetColumnSelection();
-		});
-
-		expect(store.current.currentSelection).toEqual(BLANK_SELECTION);
-
-		act(() => {
-			undo();
-		});
-
-		expect(store.current.currentSelection).toEqual({ section: 0, start: 1, end: 4 });
-	});
-
-	it('redoes selection reset.', () => {
-		const store = getTablatureStore();
-		const { redo } = getHistoryFns();
-
-		expect(store.current.currentSelection).toEqual({ section: 0, start: 1, end: 4 });
-
-		act(() => {
-			redo();
-		});
-
-		expect(store.current.currentSelection).toEqual(BLANK_SELECTION);
-	});
-});
 
 describe('[changeInstrument]', () => {
 	cleanupStore();
@@ -178,42 +62,6 @@ describe('[changeInstrument]', () => {
 		});
 
 		expect(store.current.instrument).toEqual(electricBass);
-	});
-});
-
-describe('[changeTuning]', () => {
-	cleanupStore();
-
-	it('undoes change to tuning.', () => {
-		const store = getTablatureStore();
-		const { undo } = getHistoryFns();
-
-		expect(store.current.tuning).toEqual(store.current.instrument.defaultTuning);
-
-		act(() => {
-			changeTuning([26, 33, 38, 43, 47, 52]);
-		});
-
-		expect(store.current.tuning).toEqual([26, 33, 38, 43, 47, 52]);
-
-		act(() => {
-			undo();
-		});
-
-		expect(store.current.tuning).toEqual(store.current.instrument.defaultTuning);
-	});
-
-	it('redoes change to tuning.', () => {
-		const store = getTablatureStore();
-		const { redo } = getHistoryFns();
-
-		expect(store.current.tuning).toEqual(store.current.instrument.defaultTuning);
-
-		act(() => {
-			redo();
-		});
-
-		expect(store.current.tuning).toEqual([26, 33, 38, 43, 47, 52]);
 	});
 });
 

--- a/src/modules/tablatureEditorStore/useTablatureEditorStore.ts
+++ b/src/modules/tablatureEditorStore/useTablatureEditorStore.ts
@@ -13,11 +13,10 @@ export const useTablatureEditorStore = create(
 			...createEditorSlice(...a),
 		})),
 		{
-			// don't save change history of 'ghostSelection' or 'isSelecting'
-			partialize: (state): Omit<TablatureEditorStore, 'ghostSelection' | 'isSelecting'> => {
-				// eslint-disable-next-line @typescript-eslint/no-unused-vars
-				const { ghostSelection, isSelecting, ...rest } = state;
-				return rest;
+			// Only save the change history of the tablature and instrument
+			partialize: (state): Pick<TablatureEditorStore, 'tablature' | 'instrument'> => {
+				const { tablature, instrument } = state;
+				return { tablature, instrument };
 			},
 			equality: shallow,
 			limit: 50,

--- a/src/modules/tablatureEditorStore/useTablatureHistoryStore.ts
+++ b/src/modules/tablatureEditorStore/useTablatureHistoryStore.ts
@@ -4,6 +4,6 @@ import { useStore } from 'zustand';
 import { useTablatureEditorStore } from './useTablatureEditorStore';
 
 export const useTablatureHistoryStore = <T>(
-	selector: (state: TemporalState<Omit<TablatureEditorStore, 'ghostSelection' | 'isSelecting'>>) => T,
+	selector: (state: TemporalState<Pick<TablatureEditorStore, 'tablature' | 'instrument'>>) => T,
 	equality?: (a: T, b: T) => boolean
 ) => useStore(useTablatureEditorStore.temporal, selector, equality);


### PR DESCRIPTION
Changed temporal store to only undo/redo changes to the `tablature` or `instrument`. Undo/redoing changes to the selection doesn't really make sense to do.