### PR TITLE
Feat/copy and paste actions

### DIFF
--- a/__tests__/editorSlice/copyPaste.test.ts
+++ b/__tests__/editorSlice/copyPaste.test.ts
@@ -1,0 +1,108 @@
+import { expect, jest } from '@jest/globals';
+import { resetStore } from '@modules/tablatureEditorStore/actions/resetStore';
+import { copySelectedColumns } from '@modules/tablatureEditorStore/editorSlice/actions/copySelectedColumns';
+import { pasteClipboard } from '@modules/tablatureEditorStore/editorSlice/actions/pasteClipboard';
+import { setClipboard } from '@modules/tablatureEditorStore/editorSlice/actions/setClipboard';
+import { setColumnSelection } from '@modules/tablatureEditorStore/editorSlice/actions/setColumnSelection';
+import { setSelectedColumnsFret } from '@modules/tablatureEditorStore/tablatureSlice/actions/setSelectedColumnsFret';
+import { useTablatureEditorStore } from '@modules/tablatureEditorStore/useTablatureEditorStore';
+import { validateColumnSelection } from '@modules/tablatureEditorStore/utils/validateColumnSelection';
+import { act, cleanup, renderHook } from '@testing-library/react';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const printSectionColumns = (section: Section) =>
+	console.info(section.columns.map((column) => column.cells.map((cell) => cell.fret)));
+
+beforeEach(() => {
+	jest.clearAllMocks();
+	cleanup();
+	act(() => {
+		resetStore();
+	});
+});
+
+it('[setClipboard] sets the clipboard.', () => {
+	const { result } = renderHook(() => useTablatureEditorStore((state) => state));
+
+	const clipboardColumns = new Array(5).fill(result.current.instrument.createColumnFromText('----53'));
+
+	act(() => {
+		setClipboard(clipboardColumns);
+	});
+
+	// Verifies that the clipboard matches the array of columns
+	expect(result.current.clipboard).toStrictEqual(clipboardColumns);
+});
+
+it('[copySelectedColumns] copies selected columns.', () => {
+	const { result } = renderHook(() => useTablatureEditorStore((state) => state));
+
+	act(() => {
+		setColumnSelection(0, 1, 3);
+		setSelectedColumnsFret(0, 8);
+		copySelectedColumns();
+	});
+
+	// Verifies that the clipboard matches the selected columns
+	const { section, start, end } = validateColumnSelection(result.current.currentSelection, result.current.tablature);
+	const selectedColumns = result.current.tablature.sections[section].columns.slice(start, end + 1);
+	expect(selectedColumns).toStrictEqual(result.current.clipboard);
+});
+
+it('[pasteClipboard] inserts clipboard columns when selection size == 1.', () => {
+	const { result } = renderHook(() => useTablatureEditorStore((state) => state));
+
+	const clipboardColumns = new Array(5).fill(result.current.instrument.createColumnFromText('---755'));
+
+	const section = 0;
+	const start = 1;
+	const end = 1;
+
+	const startingColumnCount = result.current.tablature.sections[section].columns.length;
+
+	act(() => {
+		setClipboard(clipboardColumns);
+		setColumnSelection(section, start, end);
+		pasteClipboard();
+	});
+
+	// Verifies that the selection reflects the inserted columns
+	const pastedColumnsStart = start + 1;
+	const pastedColumnsEnd = pastedColumnsStart + clipboardColumns.length;
+	const selectedColumns = result.current.tablature.sections[0].columns.slice(pastedColumnsStart, pastedColumnsEnd);
+	expect(selectedColumns).toStrictEqual(result.current.clipboard);
+
+	// Verifies the amount of columns in the section
+	expect(result.current.tablature.sections[section].columns.length).toBe(
+		startingColumnCount + clipboardColumns.length
+	);
+});
+
+it('[pasteClipboard] replaces selected columns with clipboard columns when selection size > 1.', () => {
+	const { result } = renderHook(() => useTablatureEditorStore((state) => state));
+
+	const clipboardColumns = new Array(7).fill(result.current.instrument.createColumnFromText('---755'));
+
+	const section = 0;
+	const start = 1;
+	const end = 3;
+
+	const startingColumnCount = result.current.tablature.sections[section].columns.length;
+
+	act(() => {
+		setClipboard(clipboardColumns);
+		setColumnSelection(section, start, end);
+		pasteClipboard();
+	});
+
+	// Verifies that the selection reflects the replaced columns
+	const pastedColumnsStart = start;
+	const pastedColumnsEnd = pastedColumnsStart + clipboardColumns.length;
+	const selectedColumns = result.current.tablature.sections[0].columns.slice(pastedColumnsStart, pastedColumnsEnd);
+	expect(selectedColumns).toStrictEqual(result.current.clipboard);
+
+	// Verifies the amount of columns in the section
+	expect(result.current.tablature.sections[section].columns.length).toBe(
+		startingColumnCount - (end - start) + clipboardColumns.length - 1
+	);
+});

--- a/src/modules/tablatureEditor/components/controls/TablatureControls.tsx
+++ b/src/modules/tablatureEditor/components/controls/TablatureControls.tsx
@@ -1,3 +1,6 @@
+import { copySelectedColumns } from '@modules/tablatureEditorStore/editorSlice/actions/copySelectedColumns';
+import { insertClipboard } from '@modules/tablatureEditorStore/editorSlice/actions/insertClipboard';
+import { pasteClipboard } from '@modules/tablatureEditorStore/editorSlice/actions/pasteClipboard';
 import { changeInstrument } from '@modules/tablatureEditorStore/tablatureSlice/actions/changeInstrument';
 import { clearSelectedColumns } from '@modules/tablatureEditorStore/tablatureSlice/actions/clearSelectedColumns';
 import { duplicateSelectedColumns } from '@modules/tablatureEditorStore/tablatureSlice/actions/duplicateSelectedColumns';
@@ -26,6 +29,15 @@ const TablatureControls = () => {
 			</button>
 			<button data-testid='duplicateSelectedColumns' onClick={() => duplicateSelectedColumns()}>
 				duplicateSelectedColumns
+			</button>
+			<button data-testid='copySelectedColumns' onClick={() => copySelectedColumns()}>
+				copySelectedColumns
+			</button>
+			<button data-testid='insertClipboard' onClick={() => insertClipboard()}>
+				insertClipboard
+			</button>
+			<button data-testid='pasteClipboard' onClick={() => pasteClipboard()}>
+				pasteClipboard
 			</button>
 			<button data-testid='pushBlankSection' onClick={() => pushBlankSection()}>
 				pushBlankSection

--- a/src/modules/tablatureEditorStore/editorSlice/actions/copySelectedColumns.ts
+++ b/src/modules/tablatureEditorStore/editorSlice/actions/copySelectedColumns.ts
@@ -1,0 +1,12 @@
+import { validateColumnSelection } from '@modules/tablatureEditorStore/utils/validateColumnSelection';
+
+import { useTablatureEditorStore } from '../../useTablatureEditorStore';
+
+export const copySelectedColumns = () =>
+	useTablatureEditorStore.setState((state) => {
+		const { section, start, end } = validateColumnSelection(state.currentSelection, state.tablature);
+
+		const columns = state.tablature.sections[section].columns.slice(start, end + 1);
+
+		state.clipboard = columns;
+	});

--- a/src/modules/tablatureEditorStore/editorSlice/actions/insertClipboard.ts
+++ b/src/modules/tablatureEditorStore/editorSlice/actions/insertClipboard.ts
@@ -1,0 +1,7 @@
+import { insertColumns } from '@modules/tablatureEditorStore/tablatureSlice/actions/utils/insertColumns';
+import { useTablatureEditorStore } from '@modules/tablatureEditorStore/useTablatureEditorStore';
+
+export const insertClipboard = () =>
+	useTablatureEditorStore.setState((state) => {
+		insertColumns(state, state.currentSelection, state.clipboard);
+	});

--- a/src/modules/tablatureEditorStore/editorSlice/actions/pasteClipboard.ts
+++ b/src/modules/tablatureEditorStore/editorSlice/actions/pasteClipboard.ts
@@ -1,0 +1,7 @@
+import { replaceColumns } from '@modules/tablatureEditorStore/tablatureSlice/actions/utils/replaceColumns';
+import { useTablatureEditorStore } from '@modules/tablatureEditorStore/useTablatureEditorStore';
+
+export const pasteClipboard = () =>
+	useTablatureEditorStore.setState((state) => {
+		replaceColumns(state, state.currentSelection, state.clipboard);
+	});

--- a/src/modules/tablatureEditorStore/editorSlice/actions/setClipboard.ts
+++ b/src/modules/tablatureEditorStore/editorSlice/actions/setClipboard.ts
@@ -1,0 +1,6 @@
+import { useTablatureEditorStore } from '@modules/tablatureEditorStore/useTablatureEditorStore';
+
+export const setClipboard = (columns: Column[]) =>
+	useTablatureEditorStore.setState((state) => {
+		state.clipboard = columns;
+	});

--- a/src/modules/tablatureEditorStore/editorSlice/constants.ts
+++ b/src/modules/tablatureEditorStore/editorSlice/constants.ts
@@ -4,4 +4,5 @@ export const editorInitialState: EditorSlice = {
 	isSelecting: false,
 	ghostSelection: BLANK_SELECTION,
 	currentSelection: BLANK_SELECTION,
+	clipboard: [],
 };

--- a/src/modules/tablatureEditorStore/editorSlice/index.d.ts
+++ b/src/modules/tablatureEditorStore/editorSlice/index.d.ts
@@ -2,6 +2,7 @@ interface EditorSlice {
 	isSelecting: boolean;
 	ghostSelection: ColumnSelection;
 	currentSelection: ColumnSelection;
+	clipboard: Columns[];
 }
 
 interface BlankColumnSelection {

--- a/src/modules/tablatureEditorStore/tablatureSlice/actions/duplicateSelectedColumns.ts
+++ b/src/modules/tablatureEditorStore/tablatureSlice/actions/duplicateSelectedColumns.ts
@@ -9,5 +9,5 @@ export const duplicateSelectedColumns = () =>
 
 		const columns = state.tablature.sections[section].columns.slice(start, end + 1);
 
-		insertColumns(state, section, end, columns);
+		insertColumns(state, state.currentSelection, columns);
 	});

--- a/src/modules/tablatureEditorStore/tablatureSlice/actions/insertColumnsAtSelection.ts
+++ b/src/modules/tablatureEditorStore/tablatureSlice/actions/insertColumnsAtSelection.ts
@@ -3,16 +3,8 @@ import { insertColumns } from './utils/insertColumns';
 
 export const insertColumnsAtSelection = (column?: Column[]) =>
 	useTablatureEditorStore.setState((state) => {
-		const { section, end } = state.currentSelection;
-
-		if (section === null || end === null)
-			return console.warn(`Attempting to insert column with null selection - section: ${section} - end: ${end}`);
-
-		if (!state.tablature.sections[section])
-			throw new Error(`Tried to insert column in non-existant section: ${section}`);
-
 		// by default, insert single blank column
 		if (!column) column = [state.instrument.BLANK_COLUMN];
 
-		insertColumns(state, section, end, column);
+		insertColumns(state, state.currentSelection, column);
 	});

--- a/src/modules/tablatureEditorStore/tablatureSlice/actions/utils/insertColumns.ts
+++ b/src/modules/tablatureEditorStore/tablatureSlice/actions/utils/insertColumns.ts
@@ -1,11 +1,7 @@
-export const insertColumns = (
-	state: TablatureEditorStore,
-	sectionIndex: number,
-	insertIndex: number,
-	columnsToInsert: Column[]
-) => {
-	const preInserted = state.tablature.sections[sectionIndex].columns.slice(0, insertIndex + 1);
-	const postInserted = state.tablature.sections[sectionIndex].columns.slice(insertIndex + 1);
+import { validateColumnSelection } from '@modules/tablatureEditorStore/utils/validateColumnSelection';
 
-	state.tablature.sections[sectionIndex].columns = [...preInserted, ...columnsToInsert, ...postInserted];
+export const insertColumns = (state: TablatureEditorStore, selection: ColumnSelection, columnsToInsert: Column[]) => {
+	const { section, end } = validateColumnSelection(selection, state.tablature);
+
+	state.tablature.sections[section].columns.splice(end + 1, 0, ...columnsToInsert);
 };

--- a/src/modules/tablatureEditorStore/tablatureSlice/actions/utils/replaceColumns.ts
+++ b/src/modules/tablatureEditorStore/tablatureSlice/actions/utils/replaceColumns.ts
@@ -1,0 +1,17 @@
+import { validateColumnSelection } from '@modules/tablatureEditorStore/utils/validateColumnSelection';
+
+import { insertColumns } from './insertColumns';
+
+export const replaceColumns = (state: TablatureEditorStore, selection: ColumnSelection, columnsToInsert: Column[]) => {
+	const { section, start, end } = validateColumnSelection(selection, state.tablature);
+	const selectionSize = end - start + 1;
+
+	if (start - end === 0) return insertColumns(state, selection, columnsToInsert);
+
+	state.tablature.sections[section].columns.splice(start, selectionSize, ...columnsToInsert);
+	const newSelection = validateColumnSelection(
+		{ section, start, end: start + columnsToInsert.length - 1 },
+		state.tablature
+	);
+	state.currentSelection = newSelection;
+};


### PR DESCRIPTION
Create a `clipboard` property in the editor store that holds an array of columns. 
Created actions that copy selected columns to `clipboard` or insert/replace columns into the tablature from `clipboard`.
Created tests for those actions.