### PR TITLE
Fix/Selection out-of-bounds after undoing

### DIFF
--- a/src/modules/tablatureEditorStore/useTablatureEditorStore.ts
+++ b/src/modules/tablatureEditorStore/useTablatureEditorStore.ts
@@ -13,12 +13,18 @@ export const useTablatureEditorStore = create(
 			...createEditorSlice(...a),
 		})),
 		{
-			// Only save the change history of the tablature and instrument
-			partialize: (state): Pick<TablatureEditorStore, 'tablature' | 'instrument'> => {
-				const { tablature, instrument } = state;
-				return { tablature, instrument };
+			// Only store the tablature, instrument, and currentSelection in the temporal store
+			partialize: (state): Pick<TablatureEditorStore, 'tablature' | 'instrument' | 'currentSelection'> => {
+				const { tablature, instrument, currentSelection } = state;
+				return { tablature, instrument, currentSelection };
 			},
-			equality: shallow,
+			// Only update the change history when tablature or instrument change
+			equality: (currentState, pastState) => {
+				return (
+					shallow(currentState.tablature, pastState.tablature) &&
+					shallow(currentState.instrument, pastState.instrument)
+				);
+			},
 			limit: 50,
 		}
 	)

--- a/src/modules/tablatureEditorStore/useTablatureHistoryStore.ts
+++ b/src/modules/tablatureEditorStore/useTablatureHistoryStore.ts
@@ -4,6 +4,6 @@ import { useStore } from 'zustand';
 import { useTablatureEditorStore } from './useTablatureEditorStore';
 
 export const useTablatureHistoryStore = <T>(
-	selector: (state: TemporalState<Pick<TablatureEditorStore, 'tablature' | 'instrument'>>) => T,
+	selector: (state: TemporalState<Pick<TablatureEditorStore, 'tablature' | 'instrument' | 'currentSelection'>>) => T,
 	equality?: (a: T, b: T) => boolean
 ) => useStore(useTablatureEditorStore.temporal, selector, equality);


### PR DESCRIPTION
Fixed an issue where `currentSelection` could sometimes become out-of-bounds when the `undo` action "removed" columns that were selected.

The temporal store now saves `currentSelection` whenever a change is made to the tablature, but not when a change is made to `currentSelection`.