### PR TITLE
Fix/undoing setInstrument tunings

### DIFF
--- a/src/modules/editorStore/__tests__/undo.test.ts
+++ b/src/modules/editorStore/__tests__/undo.test.ts
@@ -7,6 +7,7 @@ import { insertColumnsAtSelection } from '../actions/insertColumnsAtSelection';
 import { resetStore } from '../actions/resetStore';
 import { setInstrument } from '../actions/setInstrument';
 import { setSelectedColumnsFret } from '../actions/setSelectedColumnsFret';
+import { setTuning } from '../actions/setTuning';
 import { electricBass, electricGuitar } from '../constants';
 import { useTablatureEditorStore } from '../useTablatureEditorStore';
 import { useTablatureHistoryStore } from '../useTablatureHistoryStore';
@@ -32,7 +33,7 @@ describe('Undo/redo temporal store actions', () => {
 	describe('[setInstrument]', () => {
 		cleanupStore();
 
-		it('undoes change to electricBass.', () => {
+		it('does NOT undo change to instrument.', () => {
 			const store = getTablatureStore();
 			const { undo } = getHistoryFns();
 
@@ -48,20 +49,32 @@ describe('Undo/redo temporal store actions', () => {
 				undo();
 			});
 
-			expect(store.current.instrument).toEqual(electricGuitar);
+			expect(store.current.instrument).toEqual(electricBass);
 		});
+	});
 
-		it('redoes change to electricBass.', () => {
+	describe('[setTuning]', () => {
+		cleanupStore();
+
+		it('does NOT undo change to tuning.', () => {
 			const store = getTablatureStore();
-			const { redo } = getHistoryFns();
+			const { undo } = getHistoryFns();
 
-			expect(store.current.instrument).toEqual(electricGuitar);
+			const tuning = electricGuitar.commonTunings['Drop D'];
+
+			expect(store.current.tuning).toEqual(electricGuitar.defaultTuning);
 
 			act(() => {
-				redo();
+				setTuning(tuning);
 			});
 
-			expect(store.current.instrument).toEqual(electricBass);
+			expect(store.current.tuning).toEqual(tuning);
+
+			act(() => {
+				undo();
+			});
+
+			expect(store.current.tuning).toEqual(tuning);
 		});
 	});
 

--- a/src/modules/editorStore/actions/setInstrument.ts
+++ b/src/modules/editorStore/actions/setInstrument.ts
@@ -1,9 +1,10 @@
 import type { Instrument } from '@modules/editorStore/Instrument';
 
 import { useTablatureEditorStore } from '../useTablatureEditorStore';
-import { resetColumnSelection } from './resetColumnSelection';
+import { resetStore } from './resetStore';
 
 export const setInstrument = (instrument: Instrument) => {
+	resetStore();
 	useTablatureEditorStore.setState(instrument.createInitialState());
-	resetColumnSelection();
+	useTablatureEditorStore.temporal.getState().clear();
 };

--- a/src/modules/editorStore/useTablatureEditorStore.ts
+++ b/src/modules/editorStore/useTablatureEditorStore.ts
@@ -12,14 +12,12 @@ export const useTablatureEditorStore = create(
 		})),
 		{
 			// Only store the tablature, instrument, and currentSelection in the temporal store
-			partialize: (state): Pick<EditorStore, 'tablature' | 'instrument' | 'currentSelection'> => {
-				const { tablature, instrument, currentSelection } = state;
-				return { tablature, instrument, currentSelection };
+			partialize: (state): Pick<EditorStore, 'tablature' | 'currentSelection'> => {
+				const { tablature, currentSelection } = state;
+				return { tablature, currentSelection };
 			},
 			// Only update the change history when tablature or instrument change
-			equality: (currentState, pastState) =>
-				shallow(currentState.tablature, pastState.tablature) &&
-				shallow(currentState.instrument, pastState.instrument),
+			equality: (currentState, pastState) => shallow(currentState.tablature, pastState.tablature),
 			limit: 50,
 		}
 	)

--- a/src/modules/editorStore/useTablatureHistoryStore.ts
+++ b/src/modules/editorStore/useTablatureHistoryStore.ts
@@ -4,6 +4,6 @@ import { useStore } from 'zustand';
 import { useTablatureEditorStore } from './useTablatureEditorStore';
 
 export const useTablatureHistoryStore = <T>(
-	selector: (state: TemporalState<Pick<EditorStore, 'tablature' | 'instrument' | 'currentSelection'>>) => T,
+	selector: (state: TemporalState<Pick<EditorStore, 'tablature' | 'currentSelection'>>) => T,
 	equality?: (a: T, b: T) => boolean
 ) => useStore(useTablatureEditorStore.temporal, selector, equality);


### PR DESCRIPTION
Fixed a glitch where undoing after changing the instrument wouldn't undo the tunings.
Fixed this by removing `instrument` altogether from the temporal store, since it doesn't make much sense to undo anyways.