### PR TITLE
Feat/section names

### DIFF
--- a/src/modules/editorStore/Instrument.ts
+++ b/src/modules/editorStore/Instrument.ts
@@ -32,7 +32,7 @@ export class Instrument {
 			modifier: null,
 			cells: new Array<Cell>(amountOfStrings).fill(this.BLANK_CELL),
 		};
-		this.BLANK_SECTION = { columns: new Array(8).fill(this.BLANK_COLUMN) };
+		this.BLANK_SECTION = { name: 'Section 1', columns: new Array(8).fill(this.BLANK_COLUMN) };
 		this.BLANK_TABLATURE = { sections: [this.BLANK_SECTION] };
 	}
 

--- a/src/modules/editorStore/__tests__/tablatureSlice.test.ts
+++ b/src/modules/editorStore/__tests__/tablatureSlice.test.ts
@@ -88,14 +88,13 @@ describe('Tablature slice actions', () => {
 		const { result } = renderHook(() => useTablatureEditorStore((state) => state));
 
 		const currentTablature = result.current.tablature;
-		const blankSection = result.current.instrument.BLANK_SECTION;
-		const expected: Tablature = { sections: [...currentTablature.sections, blankSection] };
+		const blankSection = { ...result.current.instrument.BLANK_SECTION, name: 'Section 2' };
 
 		act(() => {
 			pushBlankSection();
 		});
 
-		expect(result.current.tablature).toEqual(expected);
+		expect(result.current.tablature.sections).toEqual([currentTablature.sections[0], blankSection]);
 	});
 
 	it('[clearSelectedColumns] sets selected columns blank.', () => {
@@ -127,9 +126,10 @@ describe('Tablature slice actions', () => {
 			insertColumnsAtSelection();
 		});
 
-		expect(result.current.tablature).toEqual({
-			sections: [{ columns: [blankColumn, ...currentTablature.sections[0].columns] }],
-		});
+		expect(result.current.tablature.sections[0].columns).toEqual([
+			blankColumn,
+			...currentTablature.sections[0].columns,
+		]);
 	});
 
 	describe('[setSelectedColumnFrets] sets specific frets of selected columns.', () => {

--- a/src/modules/editorStore/actions/pushBlankSection.ts
+++ b/src/modules/editorStore/actions/pushBlankSection.ts
@@ -1,6 +1,7 @@
 import { useTablatureEditorStore } from '../useTablatureEditorStore';
 
-export const pushBlankSection = () =>
+export const pushBlankSection = (name?: string) =>
 	useTablatureEditorStore.setState((state) => {
-		state.tablature.sections.push(state.instrument.BLANK_SECTION);
+		if (!name) name = `Section ${state.tablature.sections.length + 1}`;
+		state.tablature.sections.push({ ...state.instrument.BLANK_SECTION, name });
 	});

--- a/src/modules/editorStore/index.d.ts
+++ b/src/modules/editorStore/index.d.ts
@@ -9,7 +9,7 @@ interface Column {
 }
 
 interface Section {
-	name?: string;
+	name: string;
 	columns: Column[];
 }
 

--- a/src/modules/tablatureEditor/components/Section.tsx
+++ b/src/modules/tablatureEditor/components/Section.tsx
@@ -10,12 +10,20 @@ interface Props {
 const Section = ({ sectionIndex, section }: Props) => {
 	return (
 		<div className={styles.section} data-testid='section'>
-			<SectionTuningColumn />
-			{section.columns.map((column, columnIndex) => {
-				return (
-					<Column key={columnIndex} column={column} columnIndex={columnIndex} sectionIndex={sectionIndex} />
-				);
-			})}
+			<h2>{section.name}</h2>
+			<div className={styles['columns-container']}>
+				<SectionTuningColumn />
+				{section.columns.map((column, columnIndex) => {
+					return (
+						<Column
+							key={columnIndex}
+							column={column}
+							columnIndex={columnIndex}
+							sectionIndex={sectionIndex}
+						/>
+					);
+				})}
+			</div>
 		</div>
 	);
 };

--- a/src/modules/tablatureEditor/components/Tablature.module.scss
+++ b/src/modules/tablatureEditor/components/Tablature.module.scss
@@ -1,18 +1,27 @@
 .tablature {
-	padding: 1rem;
-	border: 1px solid $c-foreground;
-	font-family: $font-mono;
 	font-size: 12px;
+	margin-block: 2rem;
+	padding-inline: 0.5rem;
 	user-select: none;
 }
 
 .section {
-	display: flex;
-	flex-wrap: wrap;
-	row-gap: 24px;
-	margin: 0.5rem 0;
-	padding: 0.4rem 1rem 0.4rem 0.5rem;
+	padding: 0.5rem 0.75rem 0.5rem 0.75rem;
 	box-shadow: 1px 2px 7px 0 #9b9b9b;
+
+	h2 {
+		font-size: 18px;
+		font-weight: 500;
+		padding-block: 10px;
+	}
+
+	& .columns-container {
+		display: flex;
+		flex-wrap: wrap;
+		row-gap: 24px;
+		margin: 0.5rem 0;
+		font-family: $font-mono;
+	}
 }
 
 .column {

--- a/src/styles/core/resets.scss
+++ b/src/styles/core/resets.scss
@@ -21,6 +21,7 @@
 html,
 body {
 	max-width: 100vw;
+	font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;
 	overflow-x: hidden;
 }
 


### PR DESCRIPTION
Add rendering for section names. Still need to create components for entering/editing the section name in the future.

![image](https://github.com/kuanoni/next-text-tabber/assets/23709455/c42d8b9e-71ea-4233-9877-fc0a5440d6ad)
