### PR TITLE
Fix/delete columns action

### DIFF
--- a/src/modules/editorStore/actions/columns/deleteColumns.test.ts
+++ b/src/modules/editorStore/actions/columns/deleteColumns.test.ts
@@ -75,3 +75,18 @@ it('deletes columns [3-6] when selection is {0, 3, 6}.', () => {
 		[-1, -1, -1, -1, -1, -1],
 	]);
 });
+
+it('prevents column amount from dropping to 0.', () => {
+	const { result } = renderHook(() => useEditorStore((state) => state));
+
+	act(() => {
+		test_setSelection(0, 0, 7);
+		deleteColumns();
+	});
+
+	expect(result.current.currentSelection).toStrictEqual({ section: 0, start: 0, end: 0 });
+	expect(result.current.tablature.sections[0].columns.map((c) => c.id)).toEqual([8]);
+	expect(result.current.tablature.sections[0].columns.map((c) => c.cells.map((cel) => cel.fret))).toStrictEqual([
+		[-1, -1, -1, -1, -1, -1],
+	]);
+});

--- a/src/modules/editorStore/actions/columns/deleteColumns.test.ts
+++ b/src/modules/editorStore/actions/columns/deleteColumns.test.ts
@@ -17,15 +17,16 @@ beforeEach(() => {
 });
 
 it('deletes column [0] when selection is {0, 0, 0}.', () => {
-	const { result } = renderHook(() => useEditorStore((state) => state.tablature.sections[0].columns));
+	const { result } = renderHook(() => useEditorStore((state) => state));
 
 	act(() => {
 		test_setSelection(0, 0, 0);
 		deleteColumns();
 	});
 
-	expect(result.current.map((c) => c.id)).toEqual([1, 2, 3, 4, 5, 6, 7]);
-	expect(result.current.map((c) => c.cells.map((cel) => cel.fret))).toStrictEqual([
+	expect(result.current.currentSelection).toStrictEqual({ section: 0, start: 0, end: 0 });
+	expect(result.current.tablature.sections[0].columns.map((c) => c.id)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+	expect(result.current.tablature.sections[0].columns.map((c) => c.cells.map((cel) => cel.fret))).toStrictEqual([
 		[-1, -1, -1, -1, -1, -1],
 		[-1, -1, -1, -1, -1, -1],
 		[-1, -1, -1, -1, -1, -1],
@@ -37,15 +38,16 @@ it('deletes column [0] when selection is {0, 0, 0}.', () => {
 });
 
 it('deletes column [7] when selection is {0, 7, 7}.', () => {
-	const { result } = renderHook(() => useEditorStore((state) => state.tablature.sections[0].columns));
+	const { result } = renderHook(() => useEditorStore((state) => state));
 
 	act(() => {
 		test_setSelection(0, 7, 7);
 		deleteColumns();
 	});
 
-	expect(result.current.map((c) => c.id)).toEqual([0, 1, 2, 3, 4, 5, 6]);
-	expect(result.current.map((c) => c.cells.map((cel) => cel.fret))).toStrictEqual([
+	expect(result.current.currentSelection).toStrictEqual({ section: 0, start: 6, end: 6 });
+	expect(result.current.tablature.sections[0].columns.map((c) => c.id)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+	expect(result.current.tablature.sections[0].columns.map((c) => c.cells.map((cel) => cel.fret))).toStrictEqual([
 		[-1, -1, -1, -1, -1, -1],
 		[-1, -1, -1, -1, -1, -1],
 		[-1, -1, -1, -1, -1, -1],
@@ -57,15 +59,16 @@ it('deletes column [7] when selection is {0, 7, 7}.', () => {
 });
 
 it('deletes columns [3-6] when selection is {0, 3, 6}.', () => {
-	const { result } = renderHook(() => useEditorStore((state) => state.tablature.sections[0].columns));
+	const { result } = renderHook(() => useEditorStore((state) => state));
 
 	act(() => {
 		test_setSelection(0, 3, 6);
 		deleteColumns();
 	});
 
-	expect(result.current.map((c) => c.id)).toEqual([0, 1, 2, 7]);
-	expect(result.current.map((c) => c.cells.map((cel) => cel.fret))).toStrictEqual([
+	expect(result.current.currentSelection).toStrictEqual({ section: 0, start: 3, end: 3 });
+	expect(result.current.tablature.sections[0].columns.map((c) => c.id)).toEqual([0, 1, 2, 7]);
+	expect(result.current.tablature.sections[0].columns.map((c) => c.cells.map((cel) => cel.fret))).toStrictEqual([
 		[-1, -1, -1, -1, -1, -1],
 		[-1, -1, -1, -1, -1, -1],
 		[-1, -1, -1, -1, -1, -1],

--- a/src/modules/editorStore/actions/columns/deleteColumns.ts
+++ b/src/modules/editorStore/actions/columns/deleteColumns.ts
@@ -8,7 +8,12 @@ export const deleteColumns = () =>
 		const selectionSize = end - start + 1;
 		state.tablature.sections[section].columns.splice(start, selectionSize);
 
-		const columnsLen = state.tablature.sections[section].columns.length - 1;
+		let columnsLen = state.tablature.sections[section].columns.length - 1;
+
+		if (columnsLen < 0) {
+			state.tablature.sections[section].columns = [state.instrument.createBlankColumn()];
+			columnsLen = 0;
+		}
 
 		if (start > columnsLen) {
 			// If selection start is out of bounds, set selection to the last column of the section...

--- a/src/modules/editorStore/actions/columns/deleteColumns.ts
+++ b/src/modules/editorStore/actions/columns/deleteColumns.ts
@@ -7,4 +7,18 @@ export const deleteColumns = () =>
 
 		const selectionSize = end - start + 1;
 		state.tablature.sections[section].columns.splice(start, selectionSize);
+
+		const columnsLen = state.tablature.sections[section].columns.length - 1;
+
+		if (start > columnsLen) {
+			// If selection start is out of bounds, set selection to the last column of the section...
+			state.currentSelection = {
+				section,
+				start: columnsLen,
+				end: columnsLen,
+			};
+		} else {
+			// ...otherwise, just shrink the selection size down to 1 column
+			state.currentSelection = { section, start, end: start };
+		}
 	});


### PR DESCRIPTION
Fixed a bug where the selection could be pushed out of bounds by deleting columns. 
Also, if all columns are deleted, a new one will be made and put into the section, essentially preventing a section from ever being empty.